### PR TITLE
Runtime configurable Threat AttackBehaviors ("threat strategies")

### DIFF
--- a/Assets/Resources/Prefabs/CarrierInterceptor.prefab
+++ b/Assets/Resources/Prefabs/CarrierInterceptor.prefab
@@ -58,6 +58,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -133,6 +136,9 @@ TrailRenderer:
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -325,7 +331,6 @@ MonoBehaviour:
   _acceleration: {x: 0, y: 0, z: 0}
   _dragAcceleration: {x: 0, y: 0, z: 0}
   _target: {fileID: 0}
-  staticConfigFile: hydra70.json
   _showDebugVectors: 1
 --- !u!54 &3328180170527195603
 Rigidbody:

--- a/Assets/Resources/Prefabs/DummyThreatTarget.prefab
+++ b/Assets/Resources/Prefabs/DummyThreatTarget.prefab
@@ -1,0 +1,202 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4208489254168437896
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4585700050049733938}
+  - component: {fileID: 5161240963364741975}
+  - component: {fileID: 3450500162615164502}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4585700050049733938
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4208489254168437896}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 20, y: 20, z: 20}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8462434346230391091}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5161240963364741975
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4208489254168437896}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3450500162615164502
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4208489254168437896}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: f09133e0e18241045a6efe65c0415cae, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &4590233640347492898
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8315564871113561163}
+  - component: {fileID: 6203868598056538240}
+  m_Layer: 0
+  m_Name: Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8315564871113561163
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4590233640347492898}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8462434346230391091}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &6203868598056538240
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4590233640347492898}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 10
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &6438458936967544359
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8462434346230391091}
+  - component: {fileID: 5638592507962354010}
+  m_Layer: 0
+  m_Name: DummyThreatTarget
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8462434346230391091
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6438458936967544359}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8315564871113561163}
+  - {fileID: 4585700050049733938}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &5638592507962354010
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6438458936967544359}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Assets/Resources/Prefabs/DummyThreatTarget.prefab.meta
+++ b/Assets/Resources/Prefabs/DummyThreatTarget.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f6e80e11b71670e42aee874dcf19364d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/FixedWingThreat.prefab
+++ b/Assets/Resources/Prefabs/FixedWingThreat.prefab
@@ -362,7 +362,7 @@ MonoBehaviour:
   _target: {fileID: 0}
   _currentWaypoint: {x: 0, y: 0, z: 0}
   _currentPowerSetting: 0
-  _navigationGain: 3
+  _navigationGain: 50
 --- !u!114 &1645065302290878449
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/FixedWingThreat.prefab
+++ b/Assets/Resources/Prefabs/FixedWingThreat.prefab
@@ -287,8 +287,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8462434346230391091}
-  - component: {fileID: 4571646124809534626}
   - component: {fileID: 4451965530778273955}
+  - component: {fileID: -2644446524513508257}
   m_Layer: 0
   m_Name: FixedWingThreat
   m_TagString: Untagged
@@ -314,24 +314,6 @@ Transform:
   - {fileID: 9192475791974545516}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4571646124809534626
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6438458936967544359}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f532f6ee629e87643b7b75a50e83083f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _flightPhase: 0
-  _velocity: {x: 0, y: 0, z: 0}
-  _acceleration: {x: 0, y: 0, z: 0}
-  _dragAcceleration: {x: 0, y: 0, z: 0}
-  _target: {fileID: 0}
-  StaticAgentConfigFile: generic_static_config.json
 --- !u!54 &4451965530778273955
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -359,3 +341,23 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &-2644446524513508257
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6438458936967544359}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 16e40584b2154ef4a95c84e85a321999, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _flightPhase: 0
+  _velocity: {x: 0, y: 0, z: 0}
+  _acceleration: {x: 0, y: 0, z: 0}
+  _dragAcceleration: {x: 0, y: 0, z: 0}
+  _target: {fileID: 0}
+  _currentWaypoint: {x: 0, y: 0, z: 0}
+  _currentPowerSetting: 0
+  _navigationGain: 3

--- a/Assets/Resources/Prefabs/FixedWingThreat.prefab
+++ b/Assets/Resources/Prefabs/FixedWingThreat.prefab
@@ -289,6 +289,7 @@ GameObject:
   - component: {fileID: 8462434346230391091}
   - component: {fileID: 4451965530778273955}
   - component: {fileID: -2644446524513508257}
+  - component: {fileID: 1645065302290878449}
   m_Layer: 0
   m_Name: FixedWingThreat
   m_TagString: Untagged
@@ -357,7 +358,20 @@ MonoBehaviour:
   _velocity: {x: 0, y: 0, z: 0}
   _acceleration: {x: 0, y: 0, z: 0}
   _dragAcceleration: {x: 0, y: 0, z: 0}
+  _speed: 0
   _target: {fileID: 0}
   _currentWaypoint: {x: 0, y: 0, z: 0}
   _currentPowerSetting: 0
   _navigationGain: 3
+--- !u!114 &1645065302290878449
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6438458936967544359}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9b285afc8c96ee4f9ca22836fd105d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/Prefabs/RotaryWingThreat.prefab
+++ b/Assets/Resources/Prefabs/RotaryWingThreat.prefab
@@ -289,6 +289,7 @@ GameObject:
   - component: {fileID: 8462434346230391091}
   - component: {fileID: 4571646124809534626}
   - component: {fileID: 4451965530778273955}
+  - component: {fileID: 5442108668319266649}
   m_Layer: 0
   m_Name: RotaryWingThreat
   m_TagString: Untagged
@@ -330,7 +331,10 @@ MonoBehaviour:
   _velocity: {x: 0, y: 0, z: 0}
   _acceleration: {x: 0, y: 0, z: 0}
   _dragAcceleration: {x: 0, y: 0, z: 0}
+  _speed: 0
   _target: {fileID: 0}
+  _currentWaypoint: {x: 0, y: 0, z: 0}
+  _currentPowerSetting: 0
 --- !u!54 &4451965530778273955
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -358,3 +362,15 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &5442108668319266649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6438458936967544359}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9b285afc8c96ee4f9ca22836fd105d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/Agent.cs
+++ b/Assets/Scripts/Agent.cs
@@ -17,6 +17,12 @@ public abstract class Agent : MonoBehaviour {
   [SerializeField]
   protected Vector3 _dragAcceleration;
 
+  
+  [SerializeField]
+  // Only for debugging (viewing in editor)
+  // Don't bother setting this it won't be used
+  protected float _speed;
+
   [SerializeField]
   protected Agent _target;
   protected bool _isHit = false;
@@ -151,6 +157,7 @@ public abstract class Agent : MonoBehaviour {
 
   // Update is called once per frame
   protected virtual void FixedUpdate() {
+    _speed = (float)GetSpeed();
     _timeSinceLaunch += Time.fixedDeltaTime;
     _timeInPhase += Time.fixedDeltaTime;
 
@@ -260,3 +267,27 @@ public abstract class Agent : MonoBehaviour {
     return Mathf.Abs(liftAcceleration / liftDragRatio);
   }
 }
+
+
+public class DummyAgent : Agent {
+  protected override void Start() {
+    base.Start();
+  }
+
+  protected override void FixedUpdate() {
+    // Do nothing
+  }
+
+  protected override void UpdateReady(double deltaTime) {
+    // Do nothing
+  }
+
+  protected override void UpdateBoost(double deltaTime) {
+    // Do nothing
+  }
+
+  protected override void UpdateMidCourse(double deltaTime) {
+    // Do nothing
+  }
+}
+

--- a/Assets/Scripts/Agent.cs
+++ b/Assets/Scripts/Agent.cs
@@ -203,4 +203,60 @@ public abstract class Agent : MonoBehaviour {
           Quaternion.RotateTowards(transform.rotation, targetRotation, 1000f * Time.deltaTime);
     }
   }
+
+  protected Vector3 CalculateAcceleration(Vector3 accelerationInput,
+                                          bool compensateForGravity = false) {
+    Vector3 gravity = Physics.gravity;
+    if (compensateForGravity) {
+      Vector3 gravityProjection = CalculateGravityProjectionOnPitchAndYaw();
+      accelerationInput -= gravityProjection;
+    }
+
+    float airDrag = CalculateDrag();
+    float liftInducedDrag = CalculateLiftInducedDrag(accelerationInput + gravity);
+    float dragAcceleration = -(airDrag + liftInducedDrag);
+
+    // Project the drag acceleration onto the forward direction
+    Vector3 dragAccelerationAlongRoll = dragAcceleration * transform.forward;
+    _dragAcceleration = dragAccelerationAlongRoll;
+
+    return accelerationInput + gravity + dragAccelerationAlongRoll;
+  }
+    protected float CalculateMaxAcceleration() {
+    float maxReferenceAcceleration =
+        (float)(_staticAgentConfig.accelerationConfig.maxReferenceAcceleration *
+                Constants.kGravity);
+    float referenceSpeed = _staticAgentConfig.accelerationConfig.referenceSpeed;
+    return Mathf.Pow(GetComponent<Rigidbody>().linearVelocity.magnitude / referenceSpeed, 2) *
+           maxReferenceAcceleration;
+  }
+  protected Vector3 CalculateGravityProjectionOnPitchAndYaw() {
+    Vector3 gravity = Physics.gravity;
+    Vector3 pitchAxis = transform.right;
+    Vector3 yawAxis = transform.up;
+
+    // Project the gravity onto the pitch and yaw axes
+    float gravityProjectionPitchCoefficient = Vector3.Dot(gravity, pitchAxis);
+    float gravityProjectionYawCoefficient = Vector3.Dot(gravity, yawAxis);
+
+    // Return the sum of the projections
+    return gravityProjectionPitchCoefficient * pitchAxis +
+           gravityProjectionYawCoefficient * yawAxis;
+  }
+
+  private float CalculateDrag() {
+    float dragCoefficient = _staticAgentConfig.liftDragConfig.dragCoefficient;
+    float crossSectionalArea = _staticAgentConfig.bodyConfig.crossSectionalArea;
+    float mass = _staticAgentConfig.bodyConfig.mass;
+    float dynamicPressure = (float)GetDynamicPressure();
+    float dragForce = dragCoefficient * dynamicPressure * crossSectionalArea;
+    return dragForce / mass;
+  }
+
+  private float CalculateLiftInducedDrag(Vector3 accelerationInput) {
+    float liftAcceleration =
+        (accelerationInput - Vector3.Dot(accelerationInput, transform.up) * transform.up).magnitude;
+    float liftDragRatio = _staticAgentConfig.liftDragConfig.liftDragRatio;
+    return Mathf.Abs(liftAcceleration / liftDragRatio);
+  }
 }

--- a/Assets/Scripts/Behavior.meta
+++ b/Assets/Scripts/Behavior.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9bd4771e6974dfc49a84ae5fe696c9eb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Behavior/AttackBehavior.cs
+++ b/Assets/Scripts/Behavior/AttackBehavior.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class AttackBehavior
+{
+    
+
+    // Returns the next waypoint for the threat to navigate to
+    // In addition, return the power setting to use toward the waypoint
+    public abstract (Vector3 waypointPosition, StaticAgentConfig.PowerSetting power) GetNextWaypoint(Vector3 currentPosition, Vector3 targetPosition);
+
+    [System.Serializable]
+    public class DTTWaypoint
+    {
+        public float distance;
+        public float targetAltitude;
+        public StaticAgentConfig.PowerSetting power;
+    }
+
+    public class VectorWaypoint
+    {
+        public Vector3 waypointPosition;
+        public StaticAgentConfig.PowerSetting power;
+    }
+}

--- a/Assets/Scripts/Behavior/AttackBehavior.cs
+++ b/Assets/Scripts/Behavior/AttackBehavior.cs
@@ -1,25 +1,62 @@
 using System.Collections.Generic;
 using UnityEngine;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
-public abstract class AttackBehavior
+public class AttackBehavior
 {
-    
+    public string name;
+    public AttackBehaviorType attackBehaviorType;
 
+    public Vector3 targetPosition;
+    public Vector3 targetVelocity;
+    public Vector3 targetColliderSize;
+    public FlightPlan flightPlan;
     // Returns the next waypoint for the threat to navigate to
     // In addition, return the power setting to use toward the waypoint
-    public abstract (Vector3 waypointPosition, StaticAgentConfig.PowerSetting power) GetNextWaypoint(Vector3 currentPosition, Vector3 targetPosition);
-
-    [System.Serializable]
-    public class DTTWaypoint
-    {
-        public float distance;
-        public float targetAltitude;
-        public StaticAgentConfig.PowerSetting power;
+    public virtual (Vector3 waypointPosition, PowerSetting power) GetNextWaypoint(Vector3 currentPosition, Vector3 targetPosition) {
+        return (targetPosition, PowerSetting.IDLE);
     }
 
-    public class VectorWaypoint
-    {
-        public Vector3 waypointPosition;
-        public StaticAgentConfig.PowerSetting power;
+    protected static string ResolveBehaviorPath(string json) {
+        // Append "Configs/Behaviors/Attack/" to the json path if it's not already there
+        if (!json.StartsWith("Configs/Behaviors/Attack/"))
+        {
+            json = "Configs/Behaviors/Attack/" + json;
+        }
+        return json;
     }
+
+    public static AttackBehavior FromJson(string json) {
+        string resolvedPath = ResolveBehaviorPath(json);
+        string fileContent = ConfigLoader.LoadFromStreamingAssets(resolvedPath);
+        return JsonConvert.DeserializeObject<AttackBehavior>(fileContent, new JsonSerializerSettings {
+            Converters = { new Newtonsoft.Json.Converters.StringEnumConverter() }
+        });
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum AttackBehaviorType
+    {
+        DIRECT_ATTACK,
+        PREPLANNED_ATTACK,
+        SLALOM_ATTACK
+    }
+}
+
+[System.Serializable]
+public class VectorWaypoint : Waypoint
+{
+    public Vector3 waypointPosition;
+    public PowerSetting power;
+}
+
+[System.Serializable]
+public class Waypoint 
+{
+
+}
+public class FlightPlan
+{
+    public string type;
 }

--- a/Assets/Scripts/Behavior/AttackBehavior.cs.meta
+++ b/Assets/Scripts/Behavior/AttackBehavior.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9d80399b332f03349b388f9b4956585c

--- a/Assets/Scripts/Behavior/DirectAttackBehavior.cs
+++ b/Assets/Scripts/Behavior/DirectAttackBehavior.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DirectAttackBehavior : AttackBehavior
+{
+    public List<DTTWaypoint> waypoints;
+
+    // Returns the next waypoint for the threat to navigate to
+    // In addition, return the power setting to use toward the waypoint
+    public override (Vector3 waypointPosition, StaticAgentConfig.PowerSetting power) GetNextWaypoint(Vector3 currentPosition, Vector3 targetPosition)
+    {
+        if (waypoints == null || waypoints.Count == 0)
+        {
+            // If no waypoints are defined, directly target the target position
+            return (targetPosition, StaticAgentConfig.PowerSetting.MAX);
+        }
+
+        Vector3 directionToTarget = targetPosition - currentPosition;
+        float distanceToTarget = directionToTarget.magnitude;
+
+        // Find the current waypoint based on the distance to target
+        int currentWaypointIndex = 0;
+        for (int i = 0; i < waypoints.Count; i++)
+        {
+            if (distanceToTarget <= waypoints[i].distance)
+            {
+                currentWaypointIndex = i;
+                break;
+            }
+        }
+
+        Vector3 waypointPosition;
+        StaticAgentConfig.PowerSetting power;
+
+        if (currentWaypointIndex < waypoints.Count - 1)
+        {
+            // There is a next waypoint
+            DTTWaypoint nextWaypoint = waypoints[currentWaypointIndex + 1];
+            waypointPosition = targetPosition + directionToTarget.normalized * nextWaypoint.distance;
+            waypointPosition.y = nextWaypoint.targetAltitude;
+            power = nextWaypoint.power;
+        }
+        else
+        {
+            // This is the last waypoint, so target the final position
+            waypointPosition = targetPosition;
+            power = waypoints[currentWaypointIndex].power;
+        }
+
+        return (waypointPosition, power);
+    }
+
+}

--- a/Assets/Scripts/Behavior/DirectAttackBehavior.cs
+++ b/Assets/Scripts/Behavior/DirectAttackBehavior.cs
@@ -38,19 +38,20 @@ public class DirectAttackBehavior : AttackBehavior
         Vector3 waypointPosition;
         PowerSetting power;
 
-        if (currentWaypointIndex < flightPlan.waypoints.Count - 1)
+        if (currentWaypointIndex == flightPlan.waypoints.Count - 1 && distanceToTarget < flightPlan.waypoints[currentWaypointIndex].distance)
+        {
+            
+            // This is the last waypoint, so target the final position
+            waypointPosition = targetPosition;
+            power = flightPlan.waypoints[0].power;
+        }   
+        else
         {
             // There is a next waypoint
             DTTWaypoint nextWaypoint = flightPlan.waypoints[currentWaypointIndex + 1];
             waypointPosition = targetPosition + directionToTarget.normalized * nextWaypoint.distance;
             waypointPosition.y = nextWaypoint.altitude;
             power = nextWaypoint.power;
-        }
-        else
-        {
-            // This is the last waypoint, so target the final position
-            waypointPosition = targetPosition;
-            power = flightPlan.waypoints[currentWaypointIndex].power;
         }
 
         return (waypointPosition, power);

--- a/Assets/Scripts/Behavior/DirectAttackBehavior.cs
+++ b/Assets/Scripts/Behavior/DirectAttackBehavior.cs
@@ -1,18 +1,23 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 public class DirectAttackBehavior : AttackBehavior
 {
-    public List<DTTWaypoint> waypoints;
+
+
+    public new DTTFlightPlan flightPlan;
 
     // Returns the next waypoint for the threat to navigate to
     // In addition, return the power setting to use toward the waypoint
-    public override (Vector3 waypointPosition, StaticAgentConfig.PowerSetting power) GetNextWaypoint(Vector3 currentPosition, Vector3 targetPosition)
+    public override (Vector3 waypointPosition, PowerSetting power) GetNextWaypoint(Vector3 currentPosition, Vector3 targetPosition)
     {
-        if (waypoints == null || waypoints.Count == 0)
+        if (flightPlan.waypoints == null || flightPlan.waypoints.Count == 0)
         {
             // If no waypoints are defined, directly target the target position
-            return (targetPosition, StaticAgentConfig.PowerSetting.MAX);
+            return (targetPosition, PowerSetting.MAX);
         }
 
         Vector3 directionToTarget = targetPosition - currentPosition;
@@ -20,9 +25,9 @@ public class DirectAttackBehavior : AttackBehavior
 
         // Find the current waypoint based on the distance to target
         int currentWaypointIndex = 0;
-        for (int i = 0; i < waypoints.Count; i++)
+        for (int i = 0; i < flightPlan.waypoints.Count; i++)
         {
-            if (distanceToTarget <= waypoints[i].distance)
+            if (distanceToTarget <= flightPlan.waypoints[i].distance)
             {
                 currentWaypointIndex = i;
                 break;
@@ -30,24 +35,44 @@ public class DirectAttackBehavior : AttackBehavior
         }
 
         Vector3 waypointPosition;
-        StaticAgentConfig.PowerSetting power;
+        PowerSetting power;
 
-        if (currentWaypointIndex < waypoints.Count - 1)
+        if (currentWaypointIndex < flightPlan.waypoints.Count - 1)
         {
             // There is a next waypoint
-            DTTWaypoint nextWaypoint = waypoints[currentWaypointIndex + 1];
+            DTTWaypoint nextWaypoint = flightPlan.waypoints[currentWaypointIndex + 1];
             waypointPosition = targetPosition + directionToTarget.normalized * nextWaypoint.distance;
-            waypointPosition.y = nextWaypoint.targetAltitude;
+            waypointPosition.y = nextWaypoint.altitude;
             power = nextWaypoint.power;
         }
         else
         {
             // This is the last waypoint, so target the final position
             waypointPosition = targetPosition;
-            power = waypoints[currentWaypointIndex].power;
+            power = flightPlan.waypoints[currentWaypointIndex].power;
         }
 
         return (waypointPosition, power);
     }
 
+    public new static DirectAttackBehavior FromJson(string json) {
+        string resolvedPath = ResolveBehaviorPath(json);
+        string fileContent = ConfigLoader.LoadFromStreamingAssets(resolvedPath);
+        return JsonConvert.DeserializeObject<DirectAttackBehavior>(fileContent, new JsonSerializerSettings {
+            Converters = { new StringEnumConverter() }
+        });
+    }
+}
+
+[System.Serializable]
+public class DTTWaypoint : Waypoint
+{
+    public float distance;
+    public float altitude;
+    public PowerSetting power;
+}
+
+public class DTTFlightPlan : FlightPlan
+{
+    public List<DTTWaypoint> waypoints;
 }

--- a/Assets/Scripts/Behavior/DirectAttackBehavior.cs
+++ b/Assets/Scripts/Behavior/DirectAttackBehavior.cs
@@ -23,15 +23,16 @@ public class DirectAttackBehavior : AttackBehavior
         Vector3 directionToTarget = targetPosition - currentPosition;
         float distanceToTarget = directionToTarget.magnitude;
 
+        
         // Find the current waypoint based on the distance to target
         int currentWaypointIndex = 0;
         for (int i = 0; i < flightPlan.waypoints.Count; i++)
         {
-            if (distanceToTarget <= flightPlan.waypoints[i].distance)
+            if (distanceToTarget > flightPlan.waypoints[i].distance)
             {
-                currentWaypointIndex = i;
                 break;
             }
+            currentWaypointIndex = i;
         }
 
         Vector3 waypointPosition;
@@ -58,9 +59,17 @@ public class DirectAttackBehavior : AttackBehavior
     public new static DirectAttackBehavior FromJson(string json) {
         string resolvedPath = ResolveBehaviorPath(json);
         string fileContent = ConfigLoader.LoadFromStreamingAssets(resolvedPath);
-        return JsonConvert.DeserializeObject<DirectAttackBehavior>(fileContent, new JsonSerializerSettings {
+        DirectAttackBehavior behavior = JsonConvert.DeserializeObject<DirectAttackBehavior>(fileContent, new JsonSerializerSettings {
             Converters = { new StringEnumConverter() }
         });
+
+        // Sort waypoints in ascending order based on distance
+        if (behavior.flightPlan != null && behavior.flightPlan.waypoints != null)
+        {
+            behavior.flightPlan.waypoints.Sort((a, b) => a.distance.CompareTo(b.distance));
+        }
+
+        return behavior;
     }
 }
 

--- a/Assets/Scripts/Behavior/DirectAttackBehavior.cs.meta
+++ b/Assets/Scripts/Behavior/DirectAttackBehavior.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3fab0e342bc4c844b5bffde2abb83ec

--- a/Assets/Scripts/Behavior/SlalomBehavior.cs.meta
+++ b/Assets/Scripts/Behavior/SlalomBehavior.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a89a6d29e3dc1564ab2a9f225092480a

--- a/Assets/Scripts/Config/ConfigLoader.cs
+++ b/Assets/Scripts/Config/ConfigLoader.cs
@@ -58,6 +58,8 @@ public static class ConfigLoader {
         });
   }
 
+  
+
   public static void PrintSimulationConfig(SimulationConfig config) {
     if (config == null) {
       Debug.Log("SimulationConfig is null");

--- a/Assets/Scripts/Config/ConfigLoader.cs
+++ b/Assets/Scripts/Config/ConfigLoader.cs
@@ -4,7 +4,7 @@ using UnityEngine.Networking;
 using Newtonsoft.Json;
 
 public static class ConfigLoader {
-  private static string LoadFromStreamingAssets(string relativePath) {
+  public static string LoadFromStreamingAssets(string relativePath) {
     string filePath = Path.Combine(Application.streamingAssetsPath, relativePath);
 
 #if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX || UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX || UNITY_IOS

--- a/Assets/Scripts/Config/SimulationConfig.cs
+++ b/Assets/Scripts/Config/SimulationConfig.cs
@@ -32,6 +32,7 @@ public class SwarmConfig {
 public class DynamicAgentConfig {
   public string name;
   public string agent_model;
+  public string attack_behavior;
   public InitialState initial_state;
   public StandardDeviation standard_deviation;
   public DynamicConfig dynamic_config;

--- a/Assets/Scripts/Config/StaticConfig.cs
+++ b/Assets/Scripts/Config/StaticConfig.cs
@@ -1,4 +1,6 @@
 using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 [Serializable]
 public class StaticAgentConfig {
@@ -46,14 +48,6 @@ public class StaticAgentConfig {
     public float MAX;
   }
 
-  public enum PowerSetting {
-    IDLE,
-    LOW,
-    CRUISE,
-    MIL,
-    MAX
-  }
-
   public PowerTable powerTable;
 
   public AccelerationConfig accelerationConfig;
@@ -61,4 +55,13 @@ public class StaticAgentConfig {
   public LiftDragConfig liftDragConfig;
   public BodyConfig bodyConfig;
   public HitConfig hitConfig;
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum PowerSetting {
+  IDLE,
+  LOW,
+  CRUISE,
+  MIL,
+  MAX
 }

--- a/Assets/Scripts/Config/StaticConfig.cs
+++ b/Assets/Scripts/Config/StaticConfig.cs
@@ -37,6 +37,25 @@ public class StaticAgentConfig {
     public float killProbability = 0.9f;
   }
 
+  [Serializable]
+  public class PowerTable {
+    public float IDLE;
+    public float LOW;
+    public float CRUISE;
+    public float MIL;
+    public float MAX;
+  }
+
+  public enum PowerSetting {
+    IDLE,
+    LOW,
+    CRUISE,
+    MIL,
+    MAX
+  }
+
+  public PowerTable powerTable;
+
   public AccelerationConfig accelerationConfig;
   public BoostConfig boostConfig;
   public LiftDragConfig liftDragConfig;

--- a/Assets/Scripts/Interceptor.cs
+++ b/Assets/Scripts/Interceptor.cs
@@ -53,24 +53,7 @@ public class Interceptor : Agent {
 
   protected override void UpdateMidCourse(double deltaTime) {}
 
-  protected Vector3 CalculateAcceleration(Vector3 accelerationInput,
-                                          bool compensateForGravity = false) {
-    Vector3 gravity = Physics.gravity;
-    if (compensateForGravity) {
-      Vector3 gravityProjection = CalculateGravityProjectionOnPitchAndYaw();
-      accelerationInput -= gravityProjection;
-    }
 
-    float airDrag = CalculateDrag();
-    float liftInducedDrag = CalculateLiftInducedDrag(accelerationInput + gravity);
-    float dragAcceleration = -(airDrag + liftInducedDrag);
-
-    // Project the drag acceleration onto the forward direction
-    Vector3 dragAccelerationAlongRoll = dragAcceleration * transform.forward;
-    _dragAcceleration = dragAccelerationAlongRoll;
-
-    return accelerationInput + gravity + dragAccelerationAlongRoll;
-  }
 
   private void OnTriggerEnter(Collider other) {
     if (other.gameObject.name == "Floor") {
@@ -99,43 +82,7 @@ public class Interceptor : Agent {
     }
   }
 
-  protected float CalculateMaxAcceleration() {
-    float maxReferenceAcceleration =
-        (float)(_staticAgentConfig.accelerationConfig.maxReferenceAcceleration *
-                Constants.kGravity);
-    float referenceSpeed = _staticAgentConfig.accelerationConfig.referenceSpeed;
-    return Mathf.Pow(GetComponent<Rigidbody>().linearVelocity.magnitude / referenceSpeed, 2) *
-           maxReferenceAcceleration;
-  }
-  protected Vector3 CalculateGravityProjectionOnPitchAndYaw() {
-    Vector3 gravity = Physics.gravity;
-    Vector3 pitchAxis = transform.right;
-    Vector3 yawAxis = transform.up;
 
-    // Project the gravity onto the pitch and yaw axes
-    float gravityProjectionPitchCoefficient = Vector3.Dot(gravity, pitchAxis);
-    float gravityProjectionYawCoefficient = Vector3.Dot(gravity, yawAxis);
-
-    // Return the sum of the projections
-    return gravityProjectionPitchCoefficient * pitchAxis +
-           gravityProjectionYawCoefficient * yawAxis;
-  }
-
-  private float CalculateDrag() {
-    float dragCoefficient = _staticAgentConfig.liftDragConfig.dragCoefficient;
-    float crossSectionalArea = _staticAgentConfig.bodyConfig.crossSectionalArea;
-    float mass = _staticAgentConfig.bodyConfig.mass;
-    float dynamicPressure = (float)GetDynamicPressure();
-    float dragForce = dragCoefficient * dynamicPressure * crossSectionalArea;
-    return dragForce / mass;
-  }
-
-  private float CalculateLiftInducedDrag(Vector3 accelerationInput) {
-    float liftAcceleration =
-        (accelerationInput - Vector3.Dot(accelerationInput, transform.up) * transform.up).magnitude;
-    float liftDragRatio = _staticAgentConfig.liftDragConfig.liftDragRatio;
-    return Mathf.Abs(liftAcceleration / liftDragRatio);
-  }
 
   protected virtual void DrawDebugVectors() {
     if (_target != null) {

--- a/Assets/Scripts/Sensors/IdealSensor.cs
+++ b/Assets/Scripts/Sensors/IdealSensor.cs
@@ -5,6 +5,23 @@ public class IdealSensor : Sensor {
     base.Start();
   }
 
+  public override SensorOutput SenseWaypoint(Vector3 waypointPosition) {
+    SensorOutput waypointSensorOutput = new SensorOutput();
+
+    Vector3 relativePosition = waypointPosition - transform.position;
+    Vector3 relativeVelocity = Vector3.zero - GetComponent<Rigidbody>().linearVelocity;
+
+    // Sense the waypoint's position
+    PositionOutput waypointPositionSensorOutput = ComputePositionSensorOutput(relativePosition);
+    waypointSensorOutput.position = waypointPositionSensorOutput;
+
+    // Sense the waypoint's velocity
+    VelocityOutput waypointVelocitySensorOutput = ComputeVelocitySensorOutput(relativePosition, relativeVelocity);
+    waypointSensorOutput.velocity = waypointVelocitySensorOutput;
+
+    return waypointSensorOutput;
+  }
+
   public override SensorOutput Sense(Agent target) {
     SensorOutput targetSensorOutput = new SensorOutput();
 
@@ -20,52 +37,19 @@ public class IdealSensor : Sensor {
   }
 
   protected override PositionOutput SensePosition(Agent target) {
-    PositionOutput positionSensorOutput = new PositionOutput();
 
     // Calculate the relative position of the target
     Vector3 relativePosition = target.transform.position - transform.position;
 
-    // Calculate the distance (range) to the target
-    positionSensorOutput.range = relativePosition.magnitude;
-
-    // Calculate azimuth (horizontal angle relative to forward)
-    positionSensorOutput.azimuth =
-        Vector3.SignedAngle(transform.forward, relativePosition, transform.up);
-
-    // Calculate elevation (vertical angle relative to forward)
-    Vector3 flatRelativePosition = Vector3.ProjectOnPlane(relativePosition, transform.up);
-    positionSensorOutput.elevation =
-        Vector3.SignedAngle(flatRelativePosition, relativePosition, transform.right);
-
-    return positionSensorOutput;
+    return ComputePositionSensorOutput(relativePosition);
   }
 
   protected override VelocityOutput SenseVelocity(Agent target) {
-    VelocityOutput velocitySensorOutput = new VelocityOutput();
 
     // Calculate relative position and velocity
     Vector3 relativePosition = target.transform.position - transform.position;
     Vector3 relativeVelocity = target.GetVelocity() - GetComponent<Rigidbody>().linearVelocity;
 
-    // Calculate range rate (radial velocity)
-    velocitySensorOutput.range = Vector3.Dot(relativeVelocity, relativePosition.normalized);
-
-    // Project relative velocity onto a plane perpendicular to relative position
-    Vector3 tangentialVelocity =
-        Vector3.ProjectOnPlane(relativeVelocity, relativePosition.normalized);
-
-    // Calculate azimuth rate
-    Vector3 horizontalVelocity = Vector3.ProjectOnPlane(tangentialVelocity, transform.up);
-    velocitySensorOutput.azimuth =
-        Vector3.Dot(horizontalVelocity, transform.right) / relativePosition.magnitude;
-
-    // Calculate elevation rate
-    Vector3 verticalVelocity = Vector3.Project(tangentialVelocity, transform.up);
-    velocitySensorOutput.elevation = verticalVelocity.magnitude / relativePosition.magnitude;
-    if (Vector3.Dot(verticalVelocity, transform.up) < 0) {
-      velocitySensorOutput.elevation *= -1;
-    }
-
-    return velocitySensorOutput;
+    return ComputeVelocitySensorOutput(relativePosition, relativeVelocity);
   }
 }

--- a/Assets/Scripts/Sensors/Sensor.cs
+++ b/Assets/Scripts/Sensors/Sensor.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 public abstract class Sensor : MonoBehaviour {
@@ -6,6 +7,8 @@ public abstract class Sensor : MonoBehaviour {
   protected virtual void Start() {
     _agent = GetComponent<Agent>();
   }
+
+  public abstract SensorOutput SenseWaypoint(Vector3 waypointPosition);
 
   /// <summary>
   /// Main sensing method to gather information about a target agent.
@@ -35,6 +38,24 @@ public abstract class Sensor : MonoBehaviour {
   /// </remarks>
   protected abstract PositionOutput SensePosition(Agent target);
 
+  protected virtual PositionOutput ComputePositionSensorOutput(Vector3 relativePosition) {
+    PositionOutput positionSensorOutput = new PositionOutput();
+
+    // Calculate the distance (range) to the target
+    positionSensorOutput.range = relativePosition.magnitude;
+
+    // Calculate azimuth (horizontal angle relative to forward)
+    positionSensorOutput.azimuth =
+        Vector3.SignedAngle(transform.forward, relativePosition, transform.up);
+
+    // Calculate elevation (vertical angle relative to forward)
+    Vector3 flatRelativePosition = Vector3.ProjectOnPlane(relativePosition, transform.up);
+    positionSensorOutput.elevation =
+        Vector3.SignedAngle(flatRelativePosition, relativePosition, transform.right);
+
+    return positionSensorOutput;
+  }
+
   /// <summary>
   /// Calculates the relative velocity of the target agent.
   /// </summary>
@@ -50,6 +71,33 @@ public abstract class Sensor : MonoBehaviour {
   ///   Positive means the target is moving upwards.
   /// </remarks>
   protected abstract VelocityOutput SenseVelocity(Agent target);
+
+
+  protected virtual VelocityOutput ComputeVelocitySensorOutput(
+      Vector3 relativePosition, Vector3 relativeVelocity) {
+    VelocityOutput velocitySensorOutput = new VelocityOutput();
+
+    // Calculate range rate (radial velocity)
+    velocitySensorOutput.range = Vector3.Dot(relativeVelocity, relativePosition.normalized);
+
+    // Project relative velocity onto a plane perpendicular to relative position
+    Vector3 tangentialVelocity =
+        Vector3.ProjectOnPlane(relativeVelocity, relativePosition.normalized);
+
+    // Calculate azimuth rate
+    Vector3 horizontalVelocity = Vector3.ProjectOnPlane(tangentialVelocity, transform.up);
+    velocitySensorOutput.azimuth =
+        Vector3.Dot(horizontalVelocity, transform.right) / relativePosition.magnitude;
+
+    // Calculate elevation rate
+    Vector3 verticalVelocity = Vector3.Project(tangentialVelocity, transform.up);
+    velocitySensorOutput.elevation = verticalVelocity.magnitude / relativePosition.magnitude;
+    if (Vector3.Dot(verticalVelocity, transform.up) < 0) {
+      velocitySensorOutput.elevation *= -1;
+    }
+ 
+    return velocitySensorOutput;
+  }
 }
 
 public struct SensorOutput {

--- a/Assets/Scripts/SimManager.cs
+++ b/Assets/Scripts/SimManager.cs
@@ -11,7 +11,7 @@ public class SimManager : MonoBehaviour {
   /// <summary>
   /// Singleton instance of SimManager.
   /// </summary>
-  public static SimManager Instance { get; private set; }
+  public static SimManager Instance { get;  set; }
 
   /// <summary>
   /// Configuration settings for the simulation.
@@ -222,6 +222,8 @@ public class SimManager : MonoBehaviour {
 
     // Set the static agent config
     threat.SetStaticAgentConfig(threatStaticAgentConfig);
+
+    // Set the attack behavior
 
     // Subscribe events
     threat.OnInterceptHit += RegisterThreatHit;

--- a/Assets/Scripts/Threats/FixedWingThreat.cs
+++ b/Assets/Scripts/Threats/FixedWingThreat.cs
@@ -3,6 +3,13 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class FixedWingThreat : Threat {
+  [SerializeField]
+  private float _navigationGain = 3f;
+
+
+  private Vector3 _accelerationCommand;
+  private double _elapsedTime = 0;
+
   // Start is called before the first frame update
   protected override void Start() {
     base.Start();
@@ -17,5 +24,81 @@ public class FixedWingThreat : Threat {
 
   protected override void UpdateBoost(double deltaTime) {}
 
-  protected override void UpdateMidCourse(double deltaTime) {}
+  protected override void UpdateMidCourse(double deltaTime) {
+    _elapsedTime += deltaTime;
+    Vector3 accelerationInput = Vector3.zero;
+
+    if (HasAssignedTarget()) {
+      // Update waypoint and power setting
+      UpdateWaypointAndPower();
+
+      // Calculate the acceleration input using PN
+      accelerationInput = CalculateAccelerationCommand();
+
+      // Adjust velocity based on power setting
+      AdjustVelocityForPowerSetting();
+    }
+
+    // Calculate and set the total acceleration
+    Vector3 acceleration = CalculateAcceleration(accelerationInput, compensateForGravity: true);
+    GetComponent<Rigidbody>().AddForce(acceleration, ForceMode.Acceleration);
+  }
+
+  private void UpdateWaypointAndPower() {
+    // Get the next waypoint and power setting from the attack behavior
+    (_currentWaypoint, _currentPowerSetting) = _attackBehavior.GetNextWaypoint(transform.position, _target.transform.position);
+  }
+
+  private Vector3 CalculateAccelerationCommand() {
+    Vector3 accelerationCommand = Vector3.zero;
+
+    // Calculate line of sight (LOS) to the current waypoint
+    Vector3 los = _currentWaypoint - transform.position;
+    Vector3 losVelocity = Vector3.zero; // We'll use a simplified approach here
+
+    // Calculate closing velocity (simplified)
+    float closingVelocity = Vector3.Dot(-los.normalized, GetVelocity());
+
+    // Calculate LOS rates (simplified)
+    Vector3 losRate = Vector3.Cross(los.normalized, losVelocity) / los.magnitude;
+
+    // Apply Proportional Navigation
+    accelerationCommand = _navigationGain * closingVelocity * Vector3.Cross(los.normalized, losRate);
+
+    // Clamp the acceleration command to the maximum acceleration
+    float maxAcceleration = CalculateMaxAcceleration();
+    accelerationCommand = Vector3.ClampMagnitude(accelerationCommand, maxAcceleration);
+
+    // Update the stored acceleration command for debugging
+    _accelerationCommand = accelerationCommand;
+
+    return accelerationCommand;
+  }
+
+  private void AdjustVelocityForPowerSetting() {
+    // Get the target velocity for the current power setting
+    float targetVelocity = PowerTableLookup(_currentPowerSetting);
+
+    // Calculate the current velocity
+    Vector3 currentVelocity = GetVelocity();
+    float currentSpeed = currentVelocity.magnitude;
+
+    // Calculate the acceleration needed to reach the target velocity
+    float accelerationMagnitude = (targetVelocity - currentSpeed) / Time.fixedDeltaTime;
+    Vector3 velocityAdjustment = currentVelocity.normalized * accelerationMagnitude;
+
+    // Apply the velocity adjustment
+    GetComponent<Rigidbody>().AddForce(velocityAdjustment, ForceMode.Acceleration);
+  }
+
+  // Optional: Add this method to visualize debug information
+  protected virtual void OnDrawGizmos() {
+    if (Application.isPlaying) {
+      Gizmos.color = Color.yellow;
+      Gizmos.DrawLine(transform.position, _currentWaypoint);
+
+      Gizmos.color = Color.green;
+      Gizmos.DrawRay(transform.position, _accelerationCommand);
+    }
+  }
 }

--- a/Assets/Scripts/Threats/FixedWingThreat.cs
+++ b/Assets/Scripts/Threats/FixedWingThreat.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class FixedWingThreat : Threat {
   [SerializeField]
-  private float _navigationGain = 3f;
+  private float _navigationGain = 50f;
 
 
   private Vector3 _accelerationCommand;
@@ -36,7 +36,7 @@ public class FixedWingThreat : Threat {
       if (_elapsedTime >= sensorUpdatePeriod) {
         // TODO: Implement guidance filter to estimate state from sensor output
         // For now, we'll use the threat's actual state
-        _sensorOutput = GetComponent<Sensor>().Sense(_target);
+        _sensorOutput = GetComponent<Sensor>().SenseWaypoint(_currentWaypoint);
         _elapsedTime = 0;
       }
 

--- a/Assets/Scripts/Threats/FixedWingThreat.cs
+++ b/Assets/Scripts/Threats/FixedWingThreat.cs
@@ -32,38 +32,60 @@ public class FixedWingThreat : Threat {
       // Update waypoint and power setting
       UpdateWaypointAndPower();
 
+      float sensorUpdatePeriod = 1f / _dynamicAgentConfig.dynamic_config.sensor_config.frequency;
+      if (_elapsedTime >= sensorUpdatePeriod) {
+        // TODO: Implement guidance filter to estimate state from sensor output
+        // For now, we'll use the threat's actual state
+        _sensorOutput = GetComponent<Sensor>().Sense(_target);
+        _elapsedTime = 0;
+      }
+
       // Calculate the acceleration input using PN
-      accelerationInput = CalculateAccelerationCommand();
+      Vector3 pnAcceleration = CalculateAccelerationCommand(_sensorOutput);
 
       // Adjust velocity based on power setting
-      AdjustVelocityForPowerSetting();
+      Vector3 speedAdjustmentAcceleration = CalculateSpeedAdjustmentAcceleration();
+
+      // Combine the accelerations
+      accelerationInput = pnAcceleration + speedAdjustmentAcceleration;
+
+      // Clamp the total acceleration
+      float maxAcceleration = CalculateMaxAcceleration();
+      if (accelerationInput.magnitude > maxAcceleration) {
+        accelerationInput = accelerationInput.normalized * maxAcceleration;
+      }
     }
 
     // Calculate and set the total acceleration
     Vector3 acceleration = CalculateAcceleration(accelerationInput, compensateForGravity: true);
     GetComponent<Rigidbody>().AddForce(acceleration, ForceMode.Acceleration);
   }
-
   private void UpdateWaypointAndPower() {
     // Get the next waypoint and power setting from the attack behavior
-    (_currentWaypoint, _currentPowerSetting) = _attackBehavior.GetNextWaypoint(transform.position, _targetPosition);
+    // TODO: Implement support for SENSORS to update the track on the target position
+    (_currentWaypoint, _currentPowerSetting) = _attackBehavior.GetNextWaypoint(transform.position, _target.transform.position);
   }
 
-  private Vector3 CalculateAccelerationCommand() {
+  private Vector3 CalculateAccelerationCommand(SensorOutput sensorOutput) {
+    // Implement Proportional Navigation guidance law
     Vector3 accelerationCommand = Vector3.zero;
 
-    // Calculate line of sight (LOS) to the current waypoint
-    Vector3 los = _currentWaypoint - transform.position;
-    Vector3 losVelocity = Vector3.zero; // We'll use a simplified approach here
+    // Extract relevant information from sensor output
+    float los_rate_az = sensorOutput.velocity.azimuth;
+    float los_rate_el = sensorOutput.velocity.elevation;
+    float closing_velocity =
+        -sensorOutput.velocity
+             .range;  // Negative because closing velocity is opposite to range rate
 
-    // Calculate closing velocity (simplified)
-    float closingVelocity = Vector3.Dot(-los.normalized, GetVelocity());
+    // Navigation gain (adjust as needed)
+    float N = _navigationGain;
 
-    // Calculate LOS rates (simplified)
-    Vector3 losRate = Vector3.Cross(los.normalized, losVelocity) / los.magnitude;
+    // Calculate acceleration commands in azimuth and elevation planes
+    float acc_az = N * closing_velocity * los_rate_az;
+    float acc_el = N * closing_velocity * los_rate_el;
 
-    // Apply Proportional Navigation
-    accelerationCommand = _navigationGain * closingVelocity * Vector3.Cross(los.normalized, losRate);
+    // Convert acceleration commands to craft body frame
+    accelerationCommand = transform.right * acc_az + transform.up * acc_el;
 
     // Clamp the acceleration command to the maximum acceleration
     float maxAcceleration = CalculateMaxAcceleration();
@@ -71,24 +93,41 @@ public class FixedWingThreat : Threat {
 
     // Update the stored acceleration command for debugging
     _accelerationCommand = accelerationCommand;
-
     return accelerationCommand;
   }
 
-  private void AdjustVelocityForPowerSetting() {
+  private Vector3 CalculateSpeedAdjustmentAcceleration() {
     // Get the target velocity for the current power setting
-    float targetVelocity = PowerTableLookup(_currentPowerSetting);
+    float targetSpeed = PowerTableLookup(_currentPowerSetting);
 
-    // Calculate the current velocity
-    Vector3 currentVelocity = GetVelocity();
-    float currentSpeed = currentVelocity.magnitude;
+    // Calculate the current speed
+    float currentSpeed = GetVelocity().magnitude;
 
-    // Calculate the acceleration needed to reach the target velocity
-    float accelerationMagnitude = (targetVelocity - currentSpeed) / Time.fixedDeltaTime;
-    Vector3 velocityAdjustment = currentVelocity.normalized * accelerationMagnitude;
+    // Speed error
+    float speedError = targetSpeed - currentSpeed;
 
-    // Apply the velocity adjustment
-    GetComponent<Rigidbody>().AddForce(velocityAdjustment, ForceMode.Acceleration);
+    // Proportional gain for speed control
+    float speedControlGain = 1.0f; // Adjust this gain as necessary
+
+    // Desired acceleration to adjust speed
+    float desiredAccelerationMagnitude = speedControlGain * speedError;
+
+    // Limit the desired acceleration
+    float maxAcceleration = CalculateMaxAcceleration();
+    desiredAccelerationMagnitude = Mathf.Clamp(desiredAccelerationMagnitude, -maxAcceleration, maxAcceleration);
+
+    // Acceleration direction (along current velocity direction)
+    Vector3 accelerationDirection = GetVelocity().normalized;
+
+    // Handle zero velocity case
+    if (accelerationDirection.magnitude < 0.1f) {
+      accelerationDirection = transform.forward; // Default direction
+    }
+
+    // Calculate acceleration vector
+    Vector3 speedAdjustmentAcceleration = accelerationDirection * desiredAccelerationMagnitude;
+
+    return speedAdjustmentAcceleration;
   }
 
   // Optional: Add this method to visualize debug information

--- a/Assets/Scripts/Threats/FixedWingThreat.cs
+++ b/Assets/Scripts/Threats/FixedWingThreat.cs
@@ -107,7 +107,7 @@ public class FixedWingThreat : Threat {
     float speedError = targetSpeed - currentSpeed;
 
     // Proportional gain for speed control
-    float speedControlGain = 1.0f; // Adjust this gain as necessary
+    float speedControlGain = 10.0f; // Adjust this gain as necessary
 
     // Desired acceleration to adjust speed
     float desiredAccelerationMagnitude = speedControlGain * speedError;

--- a/Assets/Scripts/Threats/FixedWingThreat.cs
+++ b/Assets/Scripts/Threats/FixedWingThreat.cs
@@ -46,7 +46,7 @@ public class FixedWingThreat : Threat {
 
   private void UpdateWaypointAndPower() {
     // Get the next waypoint and power setting from the attack behavior
-    (_currentWaypoint, _currentPowerSetting) = _attackBehavior.GetNextWaypoint(transform.position, _target.transform.position);
+    (_currentWaypoint, _currentPowerSetting) = _attackBehavior.GetNextWaypoint(transform.position, _targetPosition);
   }
 
   private Vector3 CalculateAccelerationCommand() {

--- a/Assets/Scripts/Threats/RotaryWingThreat.cs
+++ b/Assets/Scripts/Threats/RotaryWingThreat.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class RotaryWingThreat : Threat {
+  private Vector3 _accelerationCommand;
+
   // Start is called before the first frame update
   protected override void Start() {
     base.Start();
@@ -17,5 +19,53 @@ public class RotaryWingThreat : Threat {
 
   protected override void UpdateBoost(double deltaTime) {}
 
-  protected override void UpdateMidCourse(double deltaTime) {}
+  protected override void UpdateMidCourse(double deltaTime) {
+    if (HasAssignedTarget()) {
+      // Update waypoint and power setting
+      UpdateWaypointAndPower();
+
+      // Calculate and apply acceleration
+      Vector3 accelerationInput = CalculateAccelerationToWaypoint();
+      ApplyAcceleration(accelerationInput);
+    }
+  }
+
+  private void UpdateWaypointAndPower() {
+    (_currentWaypoint, _currentPowerSetting) = _attackBehavior.GetNextWaypoint(transform.position, _target.transform.position);
+  }
+
+  private Vector3 CalculateAccelerationToWaypoint() {
+    Vector3 toWaypoint = _currentWaypoint - transform.position;
+    Vector3 currentVelocity = GetVelocity();
+
+    // Calculate desired velocity based on power setting
+    float desiredSpeed = PowerTableLookup(_currentPowerSetting);
+    Vector3 desiredVelocity = toWaypoint.normalized * desiredSpeed;
+
+    // Calculate acceleration needed to reach desired velocity
+    Vector3 accelerationCommand = (desiredVelocity - currentVelocity) / (float)Time.fixedDeltaTime;
+
+    // Limit acceleration magnitude
+    float maxAcceleration = CalculateMaxAcceleration();
+    accelerationCommand = Vector3.ClampMagnitude(accelerationCommand, maxAcceleration);
+
+    _accelerationCommand = accelerationCommand; // Store for debugging
+    return accelerationCommand;
+  }
+
+  private void ApplyAcceleration(Vector3 acceleration) {
+    // For RotaryWingThreat, we don't need to compensate for gravity or consider drag
+    GetComponent<Rigidbody>().AddForce(acceleration, ForceMode.Acceleration);
+  }
+
+  // Optional: Add this method to visualize debug information
+  protected virtual void OnDrawGizmos() {
+    if (Application.isPlaying) {
+      Gizmos.color = Color.yellow;
+      Gizmos.DrawLine(transform.position, _currentWaypoint);
+
+      Gizmos.color = Color.green;
+      Gizmos.DrawRay(transform.position, _accelerationCommand);
+    }
+  }
 }

--- a/Assets/Scripts/Threats/Threat.cs
+++ b/Assets/Scripts/Threats/Threat.cs
@@ -3,6 +3,32 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public abstract class Threat : Agent {
+
+  protected AttackBehavior _attackBehavior;
+  [SerializeField]
+  protected Vector3 _currentWaypoint;
+  [SerializeField]
+  protected StaticAgentConfig.PowerSetting _currentPowerSetting;
+
+  protected float PowerTableLookup(StaticAgentConfig.PowerSetting powerSetting) {
+    switch (powerSetting)
+    {
+        case StaticAgentConfig.PowerSetting.IDLE:
+            return _staticAgentConfig.powerTable.IDLE;
+        case StaticAgentConfig.PowerSetting.LOW:
+            return _staticAgentConfig.powerTable.LOW;
+        case StaticAgentConfig.PowerSetting.CRUISE:
+            return _staticAgentConfig.powerTable.CRUISE;
+        case StaticAgentConfig.PowerSetting.MIL:
+            return _staticAgentConfig.powerTable.MIL;
+        case StaticAgentConfig.PowerSetting.MAX:
+            return _staticAgentConfig.powerTable.MAX;
+        default:
+            Debug.LogError("Invalid power setting");
+            return 0f;
+    }
+  }
+
   public override bool IsAssignable() {
     return false;
   }

--- a/Assets/Scripts/Threats/Threat.cs
+++ b/Assets/Scripts/Threats/Threat.cs
@@ -10,10 +10,11 @@ public abstract class Threat : Agent {
   [SerializeField]
   protected PowerSetting _currentPowerSetting;
 
-  protected Vector3 _targetPosition;
+  protected SensorOutput _sensorOutput;
 
   public void SetAttackBehavior(AttackBehavior attackBehavior) {
     _attackBehavior = attackBehavior;
+    _target = SimManager.Instance.CreateDummyThreat(attackBehavior.targetPosition, attackBehavior.targetVelocity);
   }
 
   protected float PowerTableLookup(PowerSetting powerSetting) {

--- a/Assets/Scripts/Threats/Threat.cs
+++ b/Assets/Scripts/Threats/Threat.cs
@@ -8,20 +8,26 @@ public abstract class Threat : Agent {
   [SerializeField]
   protected Vector3 _currentWaypoint;
   [SerializeField]
-  protected StaticAgentConfig.PowerSetting _currentPowerSetting;
+  protected PowerSetting _currentPowerSetting;
 
-  protected float PowerTableLookup(StaticAgentConfig.PowerSetting powerSetting) {
+  protected Vector3 _targetPosition;
+
+  public void SetAttackBehavior(AttackBehavior attackBehavior) {
+    _attackBehavior = attackBehavior;
+  }
+
+  protected float PowerTableLookup(PowerSetting powerSetting) {
     switch (powerSetting)
     {
-        case StaticAgentConfig.PowerSetting.IDLE:
+        case PowerSetting.IDLE:
             return _staticAgentConfig.powerTable.IDLE;
-        case StaticAgentConfig.PowerSetting.LOW:
+        case PowerSetting.LOW:
             return _staticAgentConfig.powerTable.LOW;
-        case StaticAgentConfig.PowerSetting.CRUISE:
+        case PowerSetting.CRUISE:
             return _staticAgentConfig.powerTable.CRUISE;
-        case StaticAgentConfig.PowerSetting.MIL:
+        case PowerSetting.MIL:
             return _staticAgentConfig.powerTable.MIL;
-        case StaticAgentConfig.PowerSetting.MAX:
+        case PowerSetting.MAX:
             return _staticAgentConfig.powerTable.MAX;
         default:
             Debug.LogError("Invalid power setting");

--- a/Assets/StreamingAssets/Configs/1_salvo_1_hydra_7_drones.json
+++ b/Assets/StreamingAssets/Configs/1_salvo_1_hydra_7_drones.json
@@ -52,6 +52,7 @@
       "num_agents": 7,
       "dynamic_agent_config": {
         "agent_model": "quadcopter.json",
+        "attack_behavior": "default_direct_attack.json",
         "initial_state": {
           "position": { "x": 0, "y": 600, "z": 6000 },
           "rotation": { "x": 90, "y": 0, "z": 0 },

--- a/Assets/StreamingAssets/Configs/1_salvo_1_hydra_7_drones.json
+++ b/Assets/StreamingAssets/Configs/1_salvo_1_hydra_7_drones.json
@@ -66,7 +66,7 @@
           "launch_config": { "launch_time": 0 },
           "sensor_config": {
             "type": "IDEAL",
-            "frequency": 0
+            "frequency": 100
           }
         },
         "submunitions_config": {

--- a/Assets/StreamingAssets/Configs/2_salvo_2_hydra_7_quad_3_ucav.json
+++ b/Assets/StreamingAssets/Configs/2_salvo_2_hydra_7_quad_3_ucav.json
@@ -97,6 +97,7 @@
       "num_agents": 7,
       "dynamic_agent_config": {
         "agent_model": "quadcopter.json",
+        "attack_behavior": "default_direct_attack.json",
         "initial_state": {
           "position": { "x": 0, "y": 600, "z": 6000 },
           "rotation": { "x": 90, "y": 0, "z": 0 },
@@ -122,6 +123,7 @@
       "num_agents": 3,
       "dynamic_agent_config": {
         "agent_model": "ucav.json",
+        "attack_behavior": "default_direct_attack.json",
         "initial_state": {
           "position": { "x": 2000, "y": 100, "z": 4000 },
           "rotation": { "x": 90, "y": 0, "z": 0 },

--- a/Assets/StreamingAssets/Configs/2_salvo_2_hydra_7_quad_3_ucav.json
+++ b/Assets/StreamingAssets/Configs/2_salvo_2_hydra_7_quad_3_ucav.json
@@ -131,7 +131,7 @@
         },
         "standard_deviation": {
           "position": { "x": 400, "y": 30, "z": 400 },
-          "velocity": { "x": 0, "y": 0, "z": 15 }
+          "velocity": { "x": 50, "y": 20, "z": 15 }
         },
         "dynamic_config": {
           "launch_config": { "launch_time": 0 },

--- a/Assets/StreamingAssets/Configs/2_salvo_2_hydra_7_quad_3_ucav.json
+++ b/Assets/StreamingAssets/Configs/2_salvo_2_hydra_7_quad_3_ucav.json
@@ -111,7 +111,7 @@
           "launch_config": { "launch_time": 0 },
           "sensor_config": {
             "type": "IDEAL",
-            "frequency": 0
+            "frequency": 100
           }
         },
         "submunitions_config": {
@@ -120,7 +120,7 @@
       }
     },
     {
-      "num_agents": 3,
+      "num_agents": 15,
       "dynamic_agent_config": {
         "agent_model": "ucav.json",
         "attack_behavior": "default_direct_attack.json",
@@ -137,7 +137,7 @@
           "launch_config": { "launch_time": 0 },
           "sensor_config": {
             "type": "IDEAL",
-            "frequency": 0
+            "frequency": 100
           }
         },
         "submunitions_config": {

--- a/Assets/StreamingAssets/Configs/3_salvo_10_hydra_200_drones.json
+++ b/Assets/StreamingAssets/Configs/3_salvo_10_hydra_200_drones.json
@@ -142,6 +142,7 @@
       "num_agents": 200,
       "dynamic_agent_config": {
         "agent_model": "hydra70.json",
+        "attack_behavior": "default_direct_attack.json",
         "initial_state": {
           "position": { "x": 0, "y": 600, "z": 6000 },
           "rotation": { "x": 90, "y": 0, "z": 0 },

--- a/Assets/StreamingAssets/Configs/3_salvo_10_hydra_200_drones.json
+++ b/Assets/StreamingAssets/Configs/3_salvo_10_hydra_200_drones.json
@@ -156,7 +156,7 @@
           "launch_config": { "launch_time": 0 },
           "sensor_config": {
             "type": "IDEAL",
-            "frequency": 0
+            "frequency": 100
           }
         },
         "submunitions_config": {

--- a/Assets/StreamingAssets/Configs/Behaviors.meta
+++ b/Assets/StreamingAssets/Configs/Behaviors.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 714be0161db2a9b42a2ef43455f83c02
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Configs/Behaviors/Attack.meta
+++ b/Assets/StreamingAssets/Configs/Behaviors/Attack.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 985419ccc1fd4dd41b38bb40c696d3d9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Configs/Behaviors/Attack/default_direct_attack.json
+++ b/Assets/StreamingAssets/Configs/Behaviors/Attack/default_direct_attack.json
@@ -27,10 +27,10 @@
             {
                 "distance": 4000.0,
                 "altitude": 50.0,
-                "power": "MAX"
+                "power": "MIL"
             },
             {
-                "distance": 500.0,
+                "distance": 2000.0,
                 "altitude": 0.0,
                 "power": "MAX"
             }

--- a/Assets/StreamingAssets/Configs/Behaviors/Attack/default_direct_attack.json
+++ b/Assets/StreamingAssets/Configs/Behaviors/Attack/default_direct_attack.json
@@ -1,11 +1,20 @@
 {
-
     "name": "DefaultDirectAttack",
-    "type": "DirectAttack",
+    "attackBehaviorType": "DIRECT_ATTACK",
     "targetPosition": {
-        "x": 0.0,
+        "x": 0.01,
         "y": 0.0,
         "z": 0.0
+    },
+    "targetVelocity": {
+        "x": 0.0001,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "targetColliderSize": {
+        "x": 20.0,
+        "y": 20.0,
+        "z": 20.0
     },
     "flightPlan": {
         "type": "DistanceToTarget",

--- a/Assets/StreamingAssets/Configs/Behaviors/Attack/default_direct_attack.json
+++ b/Assets/StreamingAssets/Configs/Behaviors/Attack/default_direct_attack.json
@@ -1,0 +1,25 @@
+{
+
+    "name": "DefaultDirectAttack",
+    "type": "DirectAttack",
+    "targetPosition": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "flightPlan": {
+        "type": "DistanceToTarget",
+        "waypoints": [
+            {
+                "distance": 10000.0,
+                "altitude": 500.0,
+                "power": "MIL"
+            },
+            {
+                "distance": 1000.0,
+                "altitude": 100.0,
+                "power": "MAX"
+            }
+        ]
+    }
+}

--- a/Assets/StreamingAssets/Configs/Behaviors/Attack/default_direct_attack.json
+++ b/Assets/StreamingAssets/Configs/Behaviors/Attack/default_direct_attack.json
@@ -25,8 +25,13 @@
                 "power": "MIL"
             },
             {
-                "distance": 1000.0,
-                "altitude": 100.0,
+                "distance": 4000.0,
+                "altitude": 50.0,
+                "power": "MAX"
+            },
+            {
+                "distance": 500.0,
+                "altitude": 0.0,
                 "power": "MAX"
             }
         ]

--- a/Assets/StreamingAssets/Configs/Behaviors/Attack/default_direct_attack.json.meta
+++ b/Assets/StreamingAssets/Configs/Behaviors/Attack/default_direct_attack.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 96f7decd1e2a98640ae5e068ed2a5867
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Configs/Models/Threats/quadcopter.json
+++ b/Assets/StreamingAssets/Configs/Models/Threats/quadcopter.json
@@ -23,5 +23,12 @@
     "hitConfig": {
       "hitRadius": 1,
       "killProbability": 0.9
+    },
+    "powerTable": {
+        "IDLE": 0,
+        "LOW": 20,
+        "CRUISE": 40,
+        "MIL": 50,
+        "MAX": 75
     }
 }

--- a/Assets/StreamingAssets/Configs/Models/Threats/ucav.json
+++ b/Assets/StreamingAssets/Configs/Models/Threats/ucav.json
@@ -23,5 +23,12 @@
     "hitConfig": {
       "hitRadius": 1,
       "killProbability": 0.9
+    },
+    "powerTable": {
+        "IDLE": 0,
+        "LOW": 40,
+        "CRUISE": 80,
+        "MIL": 100,
+        "MAX": 120
     }
 }

--- a/Assets/Tests/EditMode/AgentTestBase.cs
+++ b/Assets/Tests/EditMode/AgentTestBase.cs
@@ -34,4 +34,13 @@ public abstract class AgentTestBase : TestBase
     protected Interceptor CreateTestInterceptor(DynamicAgentConfig config) {
         return InvokePrivateMethod<Interceptor>(simManager, "CreateInterceptor", config);
     }
+
+    protected void SetVelocity(Agent agent, Vector3 velocity)
+    {
+        Rigidbody rb = agent.GetComponent<Rigidbody>();
+        if (rb != null)
+        {
+            rb.linearVelocity = velocity;
+        }
+    }
 }

--- a/Assets/Tests/EditMode/AgentTestBase.cs
+++ b/Assets/Tests/EditMode/AgentTestBase.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+
+public abstract class AgentTestBase : TestBase
+{
+    protected SimManager simManager;
+
+    [SetUp]
+    public virtual void Setup()
+    {
+        // Initialize SimManager
+        var simManagerGameObject = new GameObject("SimManager");
+        simManager = simManagerGameObject.AddComponent<SimManager>();
+        simManager.simulationConfig = new SimulationConfig(); // Set up a basic config if needed
+
+        SimManager.Instance = simManager;
+    }
+
+    [TearDown]
+    public virtual void Teardown()
+    {
+        // Clean up SimManager
+        if (simManager != null)
+        {
+            GameObject.DestroyImmediate(simManager.gameObject);
+        }
+    }
+    protected Threat CreateTestThreat(DynamicAgentConfig config) {
+        return InvokePrivateMethod<Threat>(simManager, "CreateThreat", config);
+    }
+
+    protected Interceptor CreateTestInterceptor(DynamicAgentConfig config) {
+        return InvokePrivateMethod<Interceptor>(simManager, "CreateInterceptor", config);
+    }
+}

--- a/Assets/Tests/EditMode/AgentTestBase.cs.meta
+++ b/Assets/Tests/EditMode/AgentTestBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef33e682002053848a27ca964621b8a0

--- a/Assets/Tests/EditMode/TestBase.cs
+++ b/Assets/Tests/EditMode/TestBase.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+
+public abstract class TestBase
+{
+    protected void SetPrivateField<T>(object obj, string fieldName, T value)
+    {
+        FieldInfo field = GetFieldInfo(obj, fieldName);
+        field.SetValue(obj, value);
+    }
+
+    protected T GetPrivateField<T>(object obj, string fieldName)
+    {
+        FieldInfo field = GetFieldInfo(obj, fieldName);
+        return (T)field.GetValue(obj);
+    }
+
+    protected T InvokePrivateMethod<T>(object obj, string methodName, params object[] parameters)
+    {
+        MethodInfo method = GetMethodInfo(obj, methodName);
+        return (T)method.Invoke(obj, parameters);
+    }
+
+    protected void InvokePrivateMethod(object obj, string methodName, params object[] parameters)
+    {
+        MethodInfo method = GetMethodInfo(obj, methodName);
+        method.Invoke(obj, parameters);
+    }
+
+    private FieldInfo GetFieldInfo(object obj, string fieldName)
+    {
+        var type = obj.GetType();
+        var field = type.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        if (field == null)
+        {
+            throw new Exception($"Field '{fieldName}' not found in type '{type.FullName}'.");
+        }
+        return field;
+    }
+
+    private MethodInfo GetMethodInfo(object obj, string methodName)
+    {
+        var type = obj.GetType();
+        var method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+        if (method == null)
+        {
+            throw new Exception($"Method '{methodName}' not found in type '{type.FullName}'.");
+        }
+        return method;
+    }
+}

--- a/Assets/Tests/EditMode/TestBase.cs.meta
+++ b/Assets/Tests/EditMode/TestBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c285a677bb0054e448187b314ae78942

--- a/Assets/Tests/EditMode/ThreatTests.cs
+++ b/Assets/Tests/EditMode/ThreatTests.cs
@@ -1,6 +1,8 @@
 using System;
 using NUnit.Framework;
 using UnityEngine;
+using System.Collections.Generic;
+using System.Linq;
 
 public class ThreatTests : AgentTestBase
 {
@@ -15,6 +17,7 @@ public class ThreatTests : AgentTestBase
         var ucavConfig = new DynamicAgentConfig
         {
             agent_model = "ucav.json",
+            attack_behavior = "default_direct_attack.json",
             initial_state = new InitialState
             {
                 position = new Vector3(2000, 100, 4000),
@@ -36,6 +39,7 @@ public class ThreatTests : AgentTestBase
         var quadcopterConfig = new DynamicAgentConfig
         {
             agent_model = "quadcopter.json",
+            attack_behavior = "default_direct_attack.json",
             initial_state = new InitialState
             {
                 position = new Vector3(0, 600, 6000),
@@ -55,9 +59,16 @@ public class ThreatTests : AgentTestBase
         };
 
 
-        fixedWingThreat = CreateTestThreat(ucavConfig) as FixedWingThreat;
+        Agent threatAgent = CreateTestThreat(ucavConfig);
+        Assert.IsNotNull(threatAgent);
+        Assert.IsTrue(threatAgent is FixedWingThreat);
+        fixedWingThreat = (FixedWingThreat)threatAgent;
         Assert.IsNotNull(fixedWingThreat);
-        rotaryWingThreat = CreateTestThreat(quadcopterConfig) as RotaryWingThreat;
+
+        threatAgent = CreateTestThreat(quadcopterConfig);
+        Assert.IsNotNull(threatAgent);
+        Assert.IsTrue(threatAgent is RotaryWingThreat);
+        rotaryWingThreat = (RotaryWingThreat)threatAgent;
         Assert.IsNotNull(rotaryWingThreat);
     }
 
@@ -74,6 +85,72 @@ public class ThreatTests : AgentTestBase
         {
             GameObject.DestroyImmediate(rotaryWingThreat.gameObject);
         }
+    }
+
+    [Test]
+    public void DefaultDirectAttack_LoadedCorrectly()
+    {
+        // Arrange
+
+
+        // Act
+        DynamicAgentConfig config = new DynamicAgentConfig
+        {
+            agent_model = "ucav.json",
+            attack_behavior = "default_direct_attack.json",
+            initial_state = new InitialState(),
+            standard_deviation = new StandardDeviation(),
+            dynamic_config = new DynamicConfig()
+        };
+
+        Threat threat = CreateTestThreat(config);
+
+        // Assert
+        Assert.IsNotNull(threat, "Threat should not be null");
+
+        AttackBehavior attackBehavior = GetPrivateField<AttackBehavior>(threat, "_attackBehavior");
+        Assert.IsNotNull(attackBehavior, "Attack behavior should not be null");
+        Assert.AreEqual("DefaultDirectAttack", attackBehavior.name);
+        Assert.AreEqual(AttackBehavior.AttackBehaviorType.DIRECT_ATTACK, attackBehavior.attackBehaviorType);
+
+        Assert.IsTrue(attackBehavior is DirectAttackBehavior, "Attack behavior should be a DirectAttackBehavior");
+        DirectAttackBehavior directAttackBehavior = (DirectAttackBehavior)attackBehavior;
+
+        Vector3 targetPosition = directAttackBehavior.targetPosition;
+        Assert.AreEqual(new Vector3(0, 0, 0), targetPosition);
+
+        DTTFlightPlan flightPlan = directAttackBehavior.flightPlan;
+        Assert.IsNotNull(flightPlan, "Flight plan should not be null");
+        Assert.AreEqual("DistanceToTarget", flightPlan.type);
+
+
+        List<DTTWaypoint> dttWaypoints = flightPlan.waypoints;
+        Assert.IsNotNull(dttWaypoints, "Waypoints should not be null");
+        Assert.AreEqual(2, dttWaypoints.Count, "There should be 2 waypoints");
+
+        Assert.AreEqual(10000f, dttWaypoints[0].distance);
+        Assert.AreEqual(500f, dttWaypoints[0].altitude);
+        Assert.AreEqual(PowerSetting.MIL, dttWaypoints[0].power);
+
+        Assert.AreEqual(1000f, dttWaypoints[1].distance);
+        Assert.AreEqual(100f, dttWaypoints[1].altitude);
+        Assert.AreEqual(PowerSetting.MAX, dttWaypoints[1].power);
+
+        // Check targetVelocity
+        Vector3 targetVelocity = directAttackBehavior.targetVelocity;
+        Assert.AreEqual(new Vector3(0.0001f, 0f, 0f), targetVelocity, "Target velocity should match the config");
+
+        // Check targetColliderSize
+        Vector3 targetColliderSize = directAttackBehavior.targetColliderSize;
+        Assert.AreEqual(new Vector3(20f, 20f, 20f), targetColliderSize, "Target collider size should match the config");
+
+        // Check targetPosition (more precise check)
+        Assert.AreEqual(0.01f, targetPosition.x, 0.0001f, "Target position X should be 0.01");
+        Assert.AreEqual(0f, targetPosition.y, 0.0001f, "Target position Y should be 0");
+        Assert.AreEqual(0f, targetPosition.z, 0.0001f, "Target position Z should be 0");
+
+        // Clean up
+        GameObject.DestroyImmediate(simManager.gameObject);
     }
 
     [Test]
@@ -99,6 +176,143 @@ public class ThreatTests : AgentTestBase
         Vector3 acceleration = InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
         float maxAcceleration = InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxAcceleration");
         Assert.LessOrEqual(acceleration.magnitude, maxAcceleration);
+    }
+
+    [Test]
+    public void FixedWingThreat_CalculateAccelerationCommand_ReturnsZeroWithSimplifiedLOSRate()
+    {
+        // Arrange
+        Vector3 initialPosition = new Vector3(0, 0, 0);
+        Vector3 waypoint = new Vector3(1000, 0, 0);
+        Vector3 initialVelocity = new Vector3(100, 0, 0);
+
+        fixedWingThreat.transform.position = initialPosition;
+        SetPrivateField(fixedWingThreat, "_currentWaypoint", waypoint);
+        SetVelocity(fixedWingThreat, initialVelocity);
+
+        // Act
+        Vector3 accelerationCommand = InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationCommand");
+
+        // Assert
+        Assert.IsNotNull(accelerationCommand);
+        Assert.AreEqual(Vector3.zero, accelerationCommand, "Acceleration command should be zero with simplified LOS rate");
+    }
+
+    private class MockAttackBehavior : AttackBehavior
+    {
+        private Vector3 waypoint;
+        private PowerSetting powerSetting;
+
+        public MockAttackBehavior(Vector3 waypoint, PowerSetting powerSetting)
+        {
+            this.waypoint = waypoint;
+            this.powerSetting = powerSetting;
+            this.name = "MockAttackBehavior";
+        }
+
+        public override (Vector3, PowerSetting) GetNextWaypoint(Vector3 currentPosition, Vector3 targetPosition)
+        {
+            return (waypoint, powerSetting);
+        }
+    }
+
+    [Test]
+    public void FixedWingThreat_UpdateMidCourse_MovesTowardsWaypoint()
+    {
+        // Arrange
+        Vector3 initialPosition = new Vector3(0, 0, 0);
+        Vector3 waypoint = new Vector3(1000, 0, 0);
+        Vector3 initialVelocity = new Vector3(100, 0, 0);
+
+        fixedWingThreat.transform.position = initialPosition;
+        SetVelocity(fixedWingThreat, initialVelocity);
+
+        // Use MockAttackBehavior
+        MockAttackBehavior mockAttackBehavior = new MockAttackBehavior(waypoint, PowerSetting.MIL);
+        SetPrivateField(fixedWingThreat, "_attackBehavior", mockAttackBehavior);
+
+        // Set target
+        GameObject targetObject = new GameObject("Target");
+        targetObject.transform.position = new Vector3(2000, 0, 0);
+        SetPrivateField(fixedWingThreat, "_target", targetObject.transform);
+
+        // Act
+        double deltaTime = Time.fixedDeltaTime;
+        InvokePrivateMethod(fixedWingThreat, "UpdateMidCourse", deltaTime);
+
+        // Assert
+        Vector3 newPosition = fixedWingThreat.transform.position;
+        float initialDistance = Vector3.Distance(initialPosition, waypoint);
+        float newDistance = Vector3.Distance(newPosition, waypoint);
+        Assert.Less(newDistance, initialDistance, "Threat should move closer to the waypoint");
+    }
+
+    [Test]
+    public void RotaryWingThreat_CalculateAccelerationToWaypoint_ComputesCorrectly()
+    {
+        // Arrange
+        Vector3 initialPosition = new Vector3(0, 0, 0);
+        Vector3 waypoint = new Vector3(1000, 0, 0);
+        Vector3 initialVelocity = new Vector3(0, 0, 0);
+        float desiredSpeed = 50f;
+
+        rotaryWingThreat.transform.position = initialPosition;
+        SetPrivateField(rotaryWingThreat, "_currentWaypoint", waypoint);
+        SetVelocity(rotaryWingThreat, initialVelocity);
+        SetPrivateField(rotaryWingThreat, "_currentPowerSetting", PowerSetting.MIL);
+
+        // Assume PowerTableLookup returns 50 for PowerSetting.MIL
+        SetPrivateField(rotaryWingThreat, "_powerSettings", new Dictionary<PowerSetting, float>
+        {
+            { PowerSetting.MIL, desiredSpeed }
+        });
+
+        // Act
+        Vector3 accelerationCommand = InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
+
+        // Assert
+        Vector3 toWaypoint = waypoint - initialPosition;
+        Vector3 expectedAccelerationDir = toWaypoint.normalized;
+        float expectedAccelerationMag = desiredSpeed / (float)Time.fixedDeltaTime;
+
+        float maxAcceleration = InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxAcceleration");
+        expectedAccelerationMag = Mathf.Min(expectedAccelerationMag, maxAcceleration);
+
+        Vector3 expectedAcceleration = expectedAccelerationDir * expectedAccelerationMag;
+
+        Assert.AreEqual(expectedAcceleration.magnitude, accelerationCommand.magnitude, 0.1f, "Acceleration magnitude should match expected");
+        Assert.AreEqual(expectedAcceleration.normalized, accelerationCommand.normalized, "Acceleration direction should be towards waypoint");
+    }
+
+    [Test]
+    public void RotaryWingThreat_UpdateMidCourse_MovesTowardsWaypoint()
+    {
+        // Arrange
+        Vector3 initialPosition = new Vector3(0, 0, 0);
+        Vector3 waypoint = new Vector3(1000, 0, 0);
+        Vector3 initialVelocity = Vector3.zero;
+
+        rotaryWingThreat.transform.position = initialPosition;
+        SetVelocity(rotaryWingThreat, initialVelocity);
+
+        // Use MockAttackBehavior
+        MockAttackBehavior mockAttackBehavior = new MockAttackBehavior(waypoint, PowerSetting.MIL);
+        SetPrivateField(rotaryWingThreat, "_attackBehavior", mockAttackBehavior);
+
+        // Set target
+        GameObject targetObject = new GameObject("Target");
+        targetObject.transform.position = new Vector3(2000, 0, 0);
+        SetPrivateField(rotaryWingThreat, "_target", targetObject.transform);
+
+        // Act
+        double deltaTime = Time.fixedDeltaTime;
+        InvokePrivateMethod(rotaryWingThreat, "UpdateMidCourse", deltaTime);
+
+        // Assert
+        Vector3 newPosition = rotaryWingThreat.transform.position;
+        float initialDistance = Vector3.Distance(initialPosition, waypoint);
+        float newDistance = Vector3.Distance(newPosition, waypoint);
+        Assert.Less(newDistance, initialDistance, "Threat should move closer to the waypoint");
     }
 
     // Additional tests...

--- a/Assets/Tests/EditMode/ThreatTests.cs
+++ b/Assets/Tests/EditMode/ThreatTests.cs
@@ -220,7 +220,8 @@ public class ThreatTests : AgentTestBase
     public void FixedWingThreat_CalculateAccelerationCommand_RespectsMaxAcceleration()
     {
         SetPrivateField(fixedWingThreat, "_currentWaypoint", Vector3.one * 1000f);
-        Vector3 acceleration = InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationCommand");
+        SensorOutput sensorOutput = fixedWingThreat.GetComponent<Sensor>().SenseWaypoint(Vector3.one * 1000f);
+        Vector3 acceleration = InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationCommand", sensorOutput);
         float maxAcceleration = InvokePrivateMethod<float>(fixedWingThreat, "CalculateMaxAcceleration");
         Assert.LessOrEqual(acceleration.magnitude, maxAcceleration);
     }

--- a/Assets/Tests/EditMode/ThreatTests.cs
+++ b/Assets/Tests/EditMode/ThreatTests.cs
@@ -1,0 +1,105 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+
+public class ThreatTests : AgentTestBase
+{
+    private FixedWingThreat fixedWingThreat;
+    private RotaryWingThreat rotaryWingThreat;
+
+    public override void Setup()
+    {
+        base.Setup();
+        // Load configurations using ConfigLoader
+        // Create dynamic configurations for threats
+        var ucavConfig = new DynamicAgentConfig
+        {
+            agent_model = "ucav.json",
+            initial_state = new InitialState
+            {
+                position = new Vector3(2000, 100, 4000),
+                rotation = new Vector3(90, 0, 0),
+                velocity = new Vector3(-50, 0, -100)
+            },
+            standard_deviation = new StandardDeviation
+            {
+                position = new Vector3(400, 30, 400),
+                velocity = new Vector3(0, 0, 15)
+            },
+            dynamic_config = new DynamicConfig
+            {
+                launch_config = new LaunchConfig { launch_time = 0 },
+                sensor_config = new SensorConfig { type = SensorType.IDEAL, frequency = 100 }
+            }
+        };
+
+        var quadcopterConfig = new DynamicAgentConfig
+        {
+            agent_model = "quadcopter.json",
+            initial_state = new InitialState
+            {
+                position = new Vector3(0, 600, 6000),
+                rotation = new Vector3(90, 0, 0),
+                velocity = new Vector3(0, 0, -50)
+            },
+            standard_deviation = new StandardDeviation
+            {
+                position = new Vector3(1000, 200, 100),
+                velocity = new Vector3(0, 0, 25)
+            },
+            dynamic_config = new DynamicConfig
+            {
+                launch_config = new LaunchConfig { launch_time = 0 },
+                sensor_config = new SensorConfig { type = SensorType.IDEAL, frequency = 100 }
+            }
+        };
+
+
+        fixedWingThreat = CreateTestThreat(ucavConfig) as FixedWingThreat;
+        Assert.IsNotNull(fixedWingThreat);
+        rotaryWingThreat = CreateTestThreat(quadcopterConfig) as RotaryWingThreat;
+        Assert.IsNotNull(rotaryWingThreat);
+    }
+
+    public override void Teardown()
+    {
+        base.Teardown();
+
+        if (fixedWingThreat != null)
+        {
+            GameObject.DestroyImmediate(fixedWingThreat.gameObject);
+        }
+
+        if (rotaryWingThreat != null)
+        {
+            GameObject.DestroyImmediate(rotaryWingThreat.gameObject);
+        }
+    }
+
+    [Test]
+    public void Threat_IsNotAssignable()
+    {
+        Assert.IsFalse(fixedWingThreat.IsAssignable());
+        Assert.IsFalse(rotaryWingThreat.IsAssignable());
+    }
+
+    [Test]
+    public void FixedWingThreat_CalculateAccelerationCommand_RespectsMaxAcceleration()
+    {
+        SetPrivateField(fixedWingThreat, "_currentWaypoint", Vector3.one * 1000f);
+        Vector3 acceleration = InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationCommand");
+        float maxAcceleration = InvokePrivateMethod<float>(fixedWingThreat, "CalculateMaxAcceleration");
+        Assert.LessOrEqual(acceleration.magnitude, maxAcceleration);
+    }
+
+    [Test]
+    public void RotaryWingThreat_CalculateAccelerationToWaypoint_RespectsMaxAcceleration()
+    {
+        SetPrivateField(rotaryWingThreat, "_currentWaypoint", Vector3.one * 1000f);
+        Vector3 acceleration = InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
+        float maxAcceleration = InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxAcceleration");
+        Assert.LessOrEqual(acceleration.magnitude, maxAcceleration);
+    }
+
+    // Additional tests...
+}

--- a/Assets/Tests/EditMode/ThreatTests.cs
+++ b/Assets/Tests/EditMode/ThreatTests.cs
@@ -3,21 +3,62 @@ using NUnit.Framework;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.IO;
 public class ThreatTests : AgentTestBase
 {
     private FixedWingThreat fixedWingThreat;
     private RotaryWingThreat rotaryWingThreat;
 
+    private const string TestDirectAttackJson = @"
+    {
+        ""name"": ""TestDirectAttack"",
+        ""attackBehaviorType"": ""DIRECT_ATTACK"",
+        ""targetPosition"": {
+            ""x"": 0.01,
+            ""y"": 0.0,
+            ""z"": 0.0
+        },
+        ""targetVelocity"": {
+            ""x"": 0.0001,
+            ""y"": 0.0,
+            ""z"": 0.0
+        },
+        ""targetColliderSize"": {
+            ""x"": 20.0,
+            ""y"": 20.0,
+            ""z"": 20.0
+        },
+        ""flightPlan"": {
+            ""type"": ""DistanceToTarget"",
+            ""waypoints"": [
+                {
+                    ""distance"": 10000.0,
+                    ""altitude"": 500.0,
+                    ""power"": ""MIL""
+                },
+                {
+                    ""distance"": 5000.0,
+                    ""altitude"": 100.0,
+                    ""power"": ""MAX""
+                }
+            ]
+        }
+    }
+    ";
+
     public override void Setup()
     {
         base.Setup();
+        // Write the hard-coded JSON to the file
+        string attackConfigPath = Path.Combine(Application.streamingAssetsPath, "Configs/Behaviors/Attack/test_direct_attack.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(attackConfigPath));
+        File.WriteAllText(attackConfigPath, TestDirectAttackJson);
         // Load configurations using ConfigLoader
         // Create dynamic configurations for threats
         var ucavConfig = new DynamicAgentConfig
         {
             agent_model = "ucav.json",
-            attack_behavior = "default_direct_attack.json",
+            attack_behavior = "test_direct_attack.json",
             initial_state = new InitialState
             {
                 position = new Vector3(2000, 100, 4000),
@@ -39,7 +80,7 @@ public class ThreatTests : AgentTestBase
         var quadcopterConfig = new DynamicAgentConfig
         {
             agent_model = "quadcopter.json",
-            attack_behavior = "default_direct_attack.json",
+            attack_behavior = "test_direct_attack.json",
             initial_state = new InitialState
             {
                 position = new Vector3(0, 600, 6000),
@@ -75,6 +116,13 @@ public class ThreatTests : AgentTestBase
     public override void Teardown()
     {
         base.Teardown();
+         // Delete the attack configuration file
+        string attackConfigPath = Path.Combine(Application.streamingAssetsPath, "Configs/Behaviors/Attack/test_direct_attack.json");
+        if (File.Exists(attackConfigPath))
+        {
+            File.Delete(attackConfigPath);
+        }
+
 
         if (fixedWingThreat != null)
         {
@@ -88,69 +136,77 @@ public class ThreatTests : AgentTestBase
     }
 
     [Test]
-    public void DefaultDirectAttack_LoadedCorrectly()
+    public void TestDirectAttack_LoadedCorrectly()
     {
         // Arrange
-
-
-        // Act
-        DynamicAgentConfig config = new DynamicAgentConfig
+        try 
         {
-            agent_model = "ucav.json",
-            attack_behavior = "default_direct_attack.json",
-            initial_state = new InitialState(),
-            standard_deviation = new StandardDeviation(),
-            dynamic_config = new DynamicConfig()
-        };
+            // Act
+            DynamicAgentConfig config = new DynamicAgentConfig
+            {
+                agent_model = "ucav.json",
+                attack_behavior = "test_direct_attack.json",
+                initial_state = new InitialState(),
+                standard_deviation = new StandardDeviation(),
+                dynamic_config = new DynamicConfig()
+            };
 
-        Threat threat = CreateTestThreat(config);
+            Threat threat = CreateTestThreat(config);
 
-        // Assert
-        Assert.IsNotNull(threat, "Threat should not be null");
+            // Assert
+            Assert.IsNotNull(threat, "Threat should not be null");
 
-        AttackBehavior attackBehavior = GetPrivateField<AttackBehavior>(threat, "_attackBehavior");
-        Assert.IsNotNull(attackBehavior, "Attack behavior should not be null");
-        Assert.AreEqual("DefaultDirectAttack", attackBehavior.name);
-        Assert.AreEqual(AttackBehavior.AttackBehaviorType.DIRECT_ATTACK, attackBehavior.attackBehaviorType);
+            AttackBehavior attackBehavior = GetPrivateField<AttackBehavior>(threat, "_attackBehavior");
+            Assert.IsNotNull(attackBehavior, "Attack behavior should not be null");
+            Assert.AreEqual("TestDirectAttack", attackBehavior.name);
+            Assert.AreEqual(AttackBehavior.AttackBehaviorType.DIRECT_ATTACK, attackBehavior.attackBehaviorType);
 
-        Assert.IsTrue(attackBehavior is DirectAttackBehavior, "Attack behavior should be a DirectAttackBehavior");
-        DirectAttackBehavior directAttackBehavior = (DirectAttackBehavior)attackBehavior;
+            Assert.IsTrue(attackBehavior is DirectAttackBehavior, "Attack behavior should be a DirectAttackBehavior");
+            DirectAttackBehavior directAttackBehavior = (DirectAttackBehavior)attackBehavior;
 
-        Vector3 targetPosition = directAttackBehavior.targetPosition;
-        Assert.AreEqual(new Vector3(0, 0, 0), targetPosition);
+            Vector3 targetPosition = directAttackBehavior.targetPosition;
+            Assert.AreEqual(new Vector3(0.01f, 0, 0), targetPosition);
 
-        DTTFlightPlan flightPlan = directAttackBehavior.flightPlan;
-        Assert.IsNotNull(flightPlan, "Flight plan should not be null");
-        Assert.AreEqual("DistanceToTarget", flightPlan.type);
+            DTTFlightPlan flightPlan = directAttackBehavior.flightPlan;
+            Assert.IsNotNull(flightPlan, "Flight plan should not be null");
+            Assert.AreEqual("DistanceToTarget", flightPlan.type);
 
 
-        List<DTTWaypoint> dttWaypoints = flightPlan.waypoints;
-        Assert.IsNotNull(dttWaypoints, "Waypoints should not be null");
-        Assert.AreEqual(2, dttWaypoints.Count, "There should be 2 waypoints");
+            List<DTTWaypoint> dttWaypoints = flightPlan.waypoints;
+            Assert.IsNotNull(dttWaypoints, "Waypoints should not be null");
+            Assert.AreEqual(2, dttWaypoints.Count, "There should be 2 waypoints");
 
-        Assert.AreEqual(10000f, dttWaypoints[0].distance);
-        Assert.AreEqual(500f, dttWaypoints[0].altitude);
-        Assert.AreEqual(PowerSetting.MIL, dttWaypoints[0].power);
+            Assert.AreEqual(5000f, dttWaypoints[0].distance);
+            Assert.AreEqual(100f, dttWaypoints[0].altitude);
+            Assert.AreEqual(PowerSetting.MAX, dttWaypoints[0].power);
 
-        Assert.AreEqual(1000f, dttWaypoints[1].distance);
-        Assert.AreEqual(100f, dttWaypoints[1].altitude);
-        Assert.AreEqual(PowerSetting.MAX, dttWaypoints[1].power);
+            Assert.AreEqual(10000f, dttWaypoints[1].distance);
+            Assert.AreEqual(500f, dttWaypoints[1].altitude);
+            Assert.AreEqual(PowerSetting.MIL, dttWaypoints[1].power);
 
-        // Check targetVelocity
-        Vector3 targetVelocity = directAttackBehavior.targetVelocity;
-        Assert.AreEqual(new Vector3(0.0001f, 0f, 0f), targetVelocity, "Target velocity should match the config");
+            // Check targetVelocity
+            Vector3 targetVelocity = directAttackBehavior.targetVelocity;
+            Assert.AreEqual(new Vector3(0.0001f, 0f, 0f), targetVelocity, "Target velocity should match the config");
 
-        // Check targetColliderSize
-        Vector3 targetColliderSize = directAttackBehavior.targetColliderSize;
-        Assert.AreEqual(new Vector3(20f, 20f, 20f), targetColliderSize, "Target collider size should match the config");
+            // Check targetColliderSize
+            Vector3 targetColliderSize = directAttackBehavior.targetColliderSize;
+            Assert.AreEqual(new Vector3(20f, 20f, 20f), targetColliderSize, "Target collider size should match the config");
 
-        // Check targetPosition (more precise check)
-        Assert.AreEqual(0.01f, targetPosition.x, 0.0001f, "Target position X should be 0.01");
-        Assert.AreEqual(0f, targetPosition.y, 0.0001f, "Target position Y should be 0");
-        Assert.AreEqual(0f, targetPosition.z, 0.0001f, "Target position Z should be 0");
+            // Check targetPosition (more precise check)
+            Assert.AreEqual(0.01f, targetPosition.x, 0.0001f, "Target position X should be 0.01");
+            Assert.AreEqual(0f, targetPosition.y, 0.0001f, "Target position Y should be 0");
+            Assert.AreEqual(0f, targetPosition.z, 0.0001f, "Target position Z should be 0");
 
-        // Clean up
-        GameObject.DestroyImmediate(simManager.gameObject);
+            // Clean up
+            GameObject.DestroyImmediate(simManager.gameObject);
+        }
+        catch (AssertionException e)
+        {
+            throw new AssertionException(e.Message + "\n" +
+            "This test likely failed because you have edited " +
+            "The test string at the top of the test. Please update the test with the new values.\n" +
+            "If you need to change the test values, please update the test string at the top of the test.");
+        }
     }
 
     [Test]
@@ -178,26 +234,6 @@ public class ThreatTests : AgentTestBase
         Assert.LessOrEqual(acceleration.magnitude, maxAcceleration);
     }
 
-    [Test]
-    public void FixedWingThreat_CalculateAccelerationCommand_ReturnsZeroWithSimplifiedLOSRate()
-    {
-        // Arrange
-        Vector3 initialPosition = new Vector3(0, 0, 0);
-        Vector3 waypoint = new Vector3(1000, 0, 0);
-        Vector3 initialVelocity = new Vector3(100, 0, 0);
-
-        fixedWingThreat.transform.position = initialPosition;
-        SetPrivateField(fixedWingThreat, "_currentWaypoint", waypoint);
-        SetVelocity(fixedWingThreat, initialVelocity);
-
-        // Act
-        Vector3 accelerationCommand = InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationCommand");
-
-        // Assert
-        Assert.IsNotNull(accelerationCommand);
-        Assert.AreEqual(Vector3.zero, accelerationCommand, "Acceleration command should be zero with simplified LOS rate");
-    }
-
     private class MockAttackBehavior : AttackBehavior
     {
         private Vector3 waypoint;
@@ -216,36 +252,6 @@ public class ThreatTests : AgentTestBase
         }
     }
 
-    [Test]
-    public void FixedWingThreat_UpdateMidCourse_MovesTowardsWaypoint()
-    {
-        // Arrange
-        Vector3 initialPosition = new Vector3(0, 0, 0);
-        Vector3 waypoint = new Vector3(1000, 0, 0);
-        Vector3 initialVelocity = new Vector3(100, 0, 0);
-
-        fixedWingThreat.transform.position = initialPosition;
-        SetVelocity(fixedWingThreat, initialVelocity);
-
-        // Use MockAttackBehavior
-        MockAttackBehavior mockAttackBehavior = new MockAttackBehavior(waypoint, PowerSetting.MIL);
-        SetPrivateField(fixedWingThreat, "_attackBehavior", mockAttackBehavior);
-
-        // Set target
-        GameObject targetObject = new GameObject("Target");
-        targetObject.transform.position = new Vector3(2000, 0, 0);
-        SetPrivateField(fixedWingThreat, "_target", targetObject.transform);
-
-        // Act
-        double deltaTime = Time.fixedDeltaTime;
-        InvokePrivateMethod(fixedWingThreat, "UpdateMidCourse", deltaTime);
-
-        // Assert
-        Vector3 newPosition = fixedWingThreat.transform.position;
-        float initialDistance = Vector3.Distance(initialPosition, waypoint);
-        float newDistance = Vector3.Distance(newPosition, waypoint);
-        Assert.Less(newDistance, initialDistance, "Threat should move closer to the waypoint");
-    }
 
     [Test]
     public void RotaryWingThreat_CalculateAccelerationToWaypoint_ComputesCorrectly()
@@ -262,10 +268,9 @@ public class ThreatTests : AgentTestBase
         SetPrivateField(rotaryWingThreat, "_currentPowerSetting", PowerSetting.MIL);
 
         // Assume PowerTableLookup returns 50 for PowerSetting.MIL
-        SetPrivateField(rotaryWingThreat, "_powerSettings", new Dictionary<PowerSetting, float>
-        {
-            { PowerSetting.MIL, desiredSpeed }
-        });
+        // Assert that its true using PowerTableLookup
+        float powerSetting = InvokePrivateMethod<float>(rotaryWingThreat, "PowerTableLookup", PowerSetting.MIL);
+        Assert.AreEqual(desiredSpeed, powerSetting);
 
         // Act
         Vector3 accelerationCommand = InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
@@ -284,36 +289,7 @@ public class ThreatTests : AgentTestBase
         Assert.AreEqual(expectedAcceleration.normalized, accelerationCommand.normalized, "Acceleration direction should be towards waypoint");
     }
 
-    [Test]
-    public void RotaryWingThreat_UpdateMidCourse_MovesTowardsWaypoint()
-    {
-        // Arrange
-        Vector3 initialPosition = new Vector3(0, 0, 0);
-        Vector3 waypoint = new Vector3(1000, 0, 0);
-        Vector3 initialVelocity = Vector3.zero;
-
-        rotaryWingThreat.transform.position = initialPosition;
-        SetVelocity(rotaryWingThreat, initialVelocity);
-
-        // Use MockAttackBehavior
-        MockAttackBehavior mockAttackBehavior = new MockAttackBehavior(waypoint, PowerSetting.MIL);
-        SetPrivateField(rotaryWingThreat, "_attackBehavior", mockAttackBehavior);
-
-        // Set target
-        GameObject targetObject = new GameObject("Target");
-        targetObject.transform.position = new Vector3(2000, 0, 0);
-        SetPrivateField(rotaryWingThreat, "_target", targetObject.transform);
-
-        // Act
-        double deltaTime = Time.fixedDeltaTime;
-        InvokePrivateMethod(rotaryWingThreat, "UpdateMidCourse", deltaTime);
-
-        // Assert
-        Vector3 newPosition = rotaryWingThreat.transform.position;
-        float initialDistance = Vector3.Distance(initialPosition, waypoint);
-        float newDistance = Vector3.Distance(newPosition, waypoint);
-        Assert.Less(newDistance, initialDistance, "Threat should move closer to the waypoint");
-    }
+   
 
     // Additional tests...
 }

--- a/Assets/Tests/EditMode/ThreatTests.cs.meta
+++ b/Assets/Tests/EditMode/ThreatTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 596332a0c60012d438fb0e5a432b232b


### PR DESCRIPTION
This PR introduces AttackBehaviors, loaded from the simulation config for a threat swarm.

![image](https://github.com/user-attachments/assets/ba41e266-cef7-4ff0-88f4-92c2930f6466)

Three archetypes

- Direct Attack (implemented)
  - Provide Distance-to-target waypoints
- Preplanned Attack (not implemented)
  - Provide list of XYZ waypoints
- Slalom Attack (not implemented)
  - Provide theta_offset and distance_between_zeroes

Attack behaviors allow specification of arbitrary position/velocity/size


### Script Updates:
* [`Agent.cs`](diffhunk://#diff-6c66e32652c51f2fc4b66f851482dfc7fe841f09127fe805e2f62662dca63883R20-R25): Added a new `_speed` field for debugging, and new methods to calculate acceleration, drag, and gravity projection. Introduced a `DummyAgent` class for testing purposes. [[1]](diffhunk://#diff-6c66e32652c51f2fc4b66f851482dfc7fe841f09127fe805e2f62662dca63883R20-R25) [[2]](diffhunk://#diff-6c66e32652c51f2fc4b66f851482dfc7fe841f09127fe805e2f62662dca63883R160) [[3]](diffhunk://#diff-6c66e32652c51f2fc4b66f851482dfc7fe841f09127fe805e2f62662dca63883R213-R293)
* [`Behavior/AttackBehavior.cs`](diffhunk://#diff-1a8d0f082a55d0610ea58c2424573c197ac5628e077baf88ea2b7a2c1cc0eefcR1-R62): Introduced a new `AttackBehavior` class with methods for handling attack behaviors and waypoints. [[1]](diffhunk://#diff-1a8d0f082a55d0610ea58c2424573c197ac5628e077baf88ea2b7a2c1cc0eefcR1-R62) [[2]](diffhunk://#diff-7c6323cf8ef7f2f855cbca6ef381ea9a595d2de85e7d6fc5912c21c3b4404749R1-R2)
* [`Behavior/DirectAttackBehavior.cs`](diffhunk://#diff-827cf7c5099beaaf961c04b4642dcf36e3c4caf1034f5edbbc07778ee0491883R1-R88): Added a new `DirectAttackBehavior` class with methods to handle direct attack behaviors and waypoints. [[1]](diffhunk://#diff-827cf7c5099beaaf961c04b4642dcf36e3c4caf1034f5edbbc07778ee0491883R1-R88) [[2]](diffhunk://#diff-55e6d23ffe679761176e4221aa5a2e3e46ab8445e633a845efec725136190f47R1-R2)
