### PR TITLE
[Agent] Introduce maximum forward acceleration

### DIFF
--- a/Assets/Scripts/Agent.cs
+++ b/Assets/Scripts/Agent.cs
@@ -229,17 +229,17 @@ public abstract class Agent : MonoBehaviour {
     return accelerationInput + gravity + dragAccelerationAlongRoll;
   }
 
-  protected float CalculateMaxAcceleration() {
-    float maxReferenceAcceleration =
-        (float)(_staticAgentConfig.accelerationConfig.maxReferenceAcceleration *
+  protected float CalculateMaxForwardAcceleration() {
+    return _staticAgentConfig.accelerationConfig.maxForwardAcceleration;
+  }
+
+  protected float CalculateMaxNormalAcceleration() {
+    float maxReferenceNormalAcceleration =
+        (float)(_staticAgentConfig.accelerationConfig.maxReferenceNormalAcceleration *
                 Constants.kGravity);
     float referenceSpeed = _staticAgentConfig.accelerationConfig.referenceSpeed;
     return Mathf.Pow(GetComponent<Rigidbody>().linearVelocity.magnitude / referenceSpeed, 2) *
-           maxReferenceAcceleration;
-  }
-
-  protected float CalculateMaxForwardAcceleration() {
-    return _staticAgentConfig.accelerationConfig.maxForwardAcceleration;
+           maxReferenceNormalAcceleration;
   }
 
   protected Vector3 CalculateGravityProjectionOnPitchAndYaw() {
@@ -247,7 +247,7 @@ public abstract class Agent : MonoBehaviour {
 
     // Project the gravity onto the pitch and yaw axes
     Vector3 gravityProjectedOnPitch = Vector3.Project(gravity, transform.right);
-    Vector3 gravityPRojectedOnYaw = Vector3.Project(gravity, transform.up);
+    Vector3 gravityProjectedOnYaw = Vector3.Project(gravity, transform.up);
 
     // Return the sum of the projections
     return gravityProjectedOnPitch + gravityProjectedOnYaw;

--- a/Assets/Scripts/Agent.cs
+++ b/Assets/Scripts/Agent.cs
@@ -17,7 +17,6 @@ public abstract class Agent : MonoBehaviour {
   [SerializeField]
   protected Vector3 _dragAcceleration;
 
-  
   [SerializeField]
   // Only for debugging (viewing in editor)
   // Don't bother setting this it won't be used
@@ -31,8 +30,8 @@ public abstract class Agent : MonoBehaviour {
   protected double _timeSinceLaunch = 0;
   protected double _timeInPhase = 0;
 
-  protected DynamicAgentConfig _dynamicAgentConfig;
-  protected StaticAgentConfig _staticAgentConfig;
+  public DynamicAgentConfig _dynamicAgentConfig;
+  public StaticAgentConfig _staticAgentConfig;
 
   // Define delegates
   public delegate void InterceptHitEventHandler(Interceptor interceptor, Threat target);
@@ -229,7 +228,8 @@ public abstract class Agent : MonoBehaviour {
 
     return accelerationInput + gravity + dragAccelerationAlongRoll;
   }
-    protected float CalculateMaxAcceleration() {
+
+  protected float CalculateMaxAcceleration() {
     float maxReferenceAcceleration =
         (float)(_staticAgentConfig.accelerationConfig.maxReferenceAcceleration *
                 Constants.kGravity);
@@ -268,7 +268,6 @@ public abstract class Agent : MonoBehaviour {
   }
 }
 
-
 public class DummyAgent : Agent {
   protected override void Start() {
     base.Start();
@@ -290,4 +289,3 @@ public class DummyAgent : Agent {
     // Do nothing
   }
 }
-

--- a/Assets/Scripts/Agent.cs
+++ b/Assets/Scripts/Agent.cs
@@ -237,18 +237,20 @@ public abstract class Agent : MonoBehaviour {
     return Mathf.Pow(GetComponent<Rigidbody>().linearVelocity.magnitude / referenceSpeed, 2) *
            maxReferenceAcceleration;
   }
+
+  protected float CalculateMaxForwardAcceleration() {
+    return _staticAgentConfig.accelerationConfig.maxForwardAcceleration;
+  }
+
   protected Vector3 CalculateGravityProjectionOnPitchAndYaw() {
     Vector3 gravity = Physics.gravity;
-    Vector3 pitchAxis = transform.right;
-    Vector3 yawAxis = transform.up;
 
     // Project the gravity onto the pitch and yaw axes
-    float gravityProjectionPitchCoefficient = Vector3.Dot(gravity, pitchAxis);
-    float gravityProjectionYawCoefficient = Vector3.Dot(gravity, yawAxis);
+    Vector3 gravityProjectedOnPitch = Vector3.Project(gravity, transform.right);
+    Vector3 gravityPRojectedOnYaw = Vector3.Project(gravity, transform.up);
 
     // Return the sum of the projections
-    return gravityProjectionPitchCoefficient * pitchAxis +
-           gravityProjectionYawCoefficient * yawAxis;
+    return gravityProjectedOnPitch + gravityProjectedOnYaw;
   }
 
   private float CalculateDrag() {

--- a/Assets/Scripts/Config/StaticConfig.cs
+++ b/Assets/Scripts/Config/StaticConfig.cs
@@ -10,6 +10,7 @@ public class StaticAgentConfig {
   public class AccelerationConfig {
     public float maxReferenceAcceleration = 300f;
     public float referenceSpeed = 1000f;
+    public float maxForwardAcceleration = 50f;
   }
 
   [Serializable]
@@ -58,10 +59,4 @@ public class StaticAgentConfig {
 }
 
 [JsonConverter(typeof(StringEnumConverter))]
-public enum PowerSetting {
-  IDLE,
-  LOW,
-  CRUISE,
-  MIL,
-  MAX
-}
+public enum PowerSetting { IDLE, LOW, CRUISE, MIL, MAX }

--- a/Assets/Scripts/Config/StaticConfig.cs
+++ b/Assets/Scripts/Config/StaticConfig.cs
@@ -8,7 +8,7 @@ public class StaticAgentConfig {
   public string agentClass;
   [Serializable]
   public class AccelerationConfig {
-    public float maxReferenceAcceleration = 300f;
+    public float maxReferenceNormalAcceleration = 300f;
     public float referenceSpeed = 1000f;
     public float maxForwardAcceleration = 50f;
   }

--- a/Assets/Scripts/Interceptor.cs
+++ b/Assets/Scripts/Interceptor.cs
@@ -53,8 +53,6 @@ public class Interceptor : Agent {
 
   protected override void UpdateMidCourse(double deltaTime) {}
 
-
-
   private void OnTriggerEnter(Collider other) {
     if (other.gameObject.name == "Floor") {
       this.HandleInterceptMiss();
@@ -63,7 +61,7 @@ public class Interceptor : Agent {
     Agent otherAgent = other.gameObject.GetComponentInParent<Agent>();
     if (otherAgent != null && otherAgent.GetComponent<Threat>() != null) {
       // Check kill probability before marking as hit
-      float killProbability = _staticAgentConfig.hitConfig.killProbability;
+      float killProbability = otherAgent._staticAgentConfig.hitConfig.killProbability;
       GameObject markerObject = Instantiate(Resources.Load<GameObject>("Prefabs/HitMarkerPrefab"),
                                             transform.position, Quaternion.identity);
       if (Random.value <= killProbability) {
@@ -81,8 +79,6 @@ public class Interceptor : Agent {
       }
     }
   }
-
-
 
   protected virtual void DrawDebugVectors() {
     if (_target != null) {

--- a/Assets/Scripts/Interceptors/MissileInterceptor.cs
+++ b/Assets/Scripts/Interceptors/MissileInterceptor.cs
@@ -60,9 +60,9 @@ public class MissileInterceptor : Interceptor {
     // Convert acceleration commands to craft body frame
     accelerationCommand = transform.right * acc_az + transform.up * acc_el;
 
-    // Clamp the acceleration command to the maximum acceleration
-    float maxAcceleration = CalculateMaxAcceleration();
-    accelerationCommand = Vector3.ClampMagnitude(accelerationCommand, maxAcceleration);
+    // Clamp the normal acceleration command to the maximum normal acceleration
+    float maxNormalAcceleration = CalculateMaxNormalAcceleration();
+    accelerationCommand = Vector3.ClampMagnitude(accelerationCommand, maxNormalAcceleration);
 
     // Update the stored acceleration command for debugging
     _accelerationCommand = accelerationCommand;

--- a/Assets/Scripts/Threats/FixedWingThreat.cs
+++ b/Assets/Scripts/Threats/FixedWingThreat.cs
@@ -6,7 +6,6 @@ public class FixedWingThreat : Threat {
   [SerializeField]
   private float _navigationGain = 50f;
 
-
   private Vector3 _accelerationCommand;
   private double _elapsedTime = 0;
 
@@ -48,22 +47,18 @@ public class FixedWingThreat : Threat {
 
       // Combine the accelerations
       accelerationInput = pnAcceleration + speedAdjustmentAcceleration;
-
-      // Clamp the total acceleration
-      float maxAcceleration = CalculateMaxAcceleration();
-      if (accelerationInput.magnitude > maxAcceleration) {
-        accelerationInput = accelerationInput.normalized * maxAcceleration;
-      }
     }
 
     // Calculate and set the total acceleration
     Vector3 acceleration = CalculateAcceleration(accelerationInput, compensateForGravity: true);
     GetComponent<Rigidbody>().AddForce(acceleration, ForceMode.Acceleration);
   }
+
   private void UpdateWaypointAndPower() {
     // Get the next waypoint and power setting from the attack behavior
     // TODO: Implement support for SENSORS to update the track on the target position
-    (_currentWaypoint, _currentPowerSetting) = _attackBehavior.GetNextWaypoint(transform.position, _target.transform.position);
+    (_currentWaypoint, _currentPowerSetting) =
+        _attackBehavior.GetNextWaypoint(transform.position, _target.transform.position);
   }
 
   private Vector3 CalculateAccelerationCommand(SensorOutput sensorOutput) {
@@ -107,21 +102,22 @@ public class FixedWingThreat : Threat {
     float speedError = targetSpeed - currentSpeed;
 
     // Proportional gain for speed control
-    float speedControlGain = 10.0f; // Adjust this gain as necessary
+    float speedControlGain = 10.0f;  // Adjust this gain as necessary
 
     // Desired acceleration to adjust speed
     float desiredAccelerationMagnitude = speedControlGain * speedError;
 
     // Limit the desired acceleration
-    float maxAcceleration = CalculateMaxAcceleration();
-    desiredAccelerationMagnitude = Mathf.Clamp(desiredAccelerationMagnitude, -maxAcceleration, maxAcceleration);
+    float maxAcceleration = CalculateMaxForwardAcceleration();
+    desiredAccelerationMagnitude =
+        Mathf.Clamp(desiredAccelerationMagnitude, -maxAcceleration, maxAcceleration);
 
     // Acceleration direction (along current velocity direction)
     Vector3 accelerationDirection = GetVelocity().normalized;
 
     // Handle zero velocity case
     if (accelerationDirection.magnitude < 0.1f) {
-      accelerationDirection = transform.forward; // Default direction
+      accelerationDirection = transform.forward;  // Default direction
     }
 
     // Calculate acceleration vector

--- a/Assets/Scripts/Threats/FixedWingThreat.cs
+++ b/Assets/Scripts/Threats/FixedWingThreat.cs
@@ -82,9 +82,9 @@ public class FixedWingThreat : Threat {
     // Convert acceleration commands to craft body frame
     accelerationCommand = transform.right * acc_az + transform.up * acc_el;
 
-    // Clamp the acceleration command to the maximum acceleration
-    float maxAcceleration = CalculateMaxAcceleration();
-    accelerationCommand = Vector3.ClampMagnitude(accelerationCommand, maxAcceleration);
+    // Clamp the normal acceleration command to the maximum normal acceleration
+    float maxNormalAcceleration = CalculateMaxNormalAcceleration();
+    accelerationCommand = Vector3.ClampMagnitude(accelerationCommand, maxNormalAcceleration);
 
     // Update the stored acceleration command for debugging
     _accelerationCommand = accelerationCommand;
@@ -108,9 +108,9 @@ public class FixedWingThreat : Threat {
     float desiredAccelerationMagnitude = speedControlGain * speedError;
 
     // Limit the desired acceleration
-    float maxAcceleration = CalculateMaxForwardAcceleration();
+    float maxForwardAcceleration = CalculateMaxForwardAcceleration();
     desiredAccelerationMagnitude =
-        Mathf.Clamp(desiredAccelerationMagnitude, -maxAcceleration, maxAcceleration);
+        Mathf.Clamp(desiredAccelerationMagnitude, -maxForwardAcceleration, maxForwardAcceleration);
 
     // Acceleration direction (along current velocity direction)
     Vector3 accelerationDirection = GetVelocity().normalized;

--- a/Assets/Scripts/Threats/RotaryWingThreat.cs
+++ b/Assets/Scripts/Threats/RotaryWingThreat.cs
@@ -31,7 +31,8 @@ public class RotaryWingThreat : Threat {
   }
 
   private void UpdateWaypointAndPower() {
-    (_currentWaypoint, _currentPowerSetting) = _attackBehavior.GetNextWaypoint(transform.position, _target.transform.position);
+    (_currentWaypoint, _currentPowerSetting) =
+        _attackBehavior.GetNextWaypoint(transform.position, _target.transform.position);
   }
 
   private Vector3 CalculateAccelerationToWaypoint() {
@@ -44,12 +45,19 @@ public class RotaryWingThreat : Threat {
 
     // Calculate acceleration needed to reach desired velocity
     Vector3 accelerationCommand = (desiredVelocity - currentVelocity) / (float)Time.fixedDeltaTime;
+    Vector3 forwardAccelerationCommand = Vector3.Project(accelerationCommand, transform.forward);
+    Vector3 normalAccelerationCommand = accelerationCommand - forwardAccelerationCommand;
 
     // Limit acceleration magnitude
-    float maxAcceleration = CalculateMaxAcceleration();
-    accelerationCommand = Vector3.ClampMagnitude(accelerationCommand, maxAcceleration);
+    float maxForwardAcceleration = CalculateMaxForwardAcceleration();
+    forwardAccelerationCommand =
+        Vector3.ClampMagnitude(forwardAccelerationCommand, maxForwardAcceleration);
+    float maxNormalAcceleration = CalculateMaxAcceleration();
+    normalAccelerationCommand =
+        Vector3.ClampMagnitude(normalAccelerationCommand, maxNormalAcceleration);
+    accelerationCommand = forwardAccelerationCommand + normalAccelerationCommand;
 
-    _accelerationCommand = accelerationCommand; // Store for debugging
+    _accelerationCommand = accelerationCommand;  // Store for debugging
     return accelerationCommand;
   }
 

--- a/Assets/Scripts/Threats/RotaryWingThreat.cs
+++ b/Assets/Scripts/Threats/RotaryWingThreat.cs
@@ -52,7 +52,7 @@ public class RotaryWingThreat : Threat {
     float maxForwardAcceleration = CalculateMaxForwardAcceleration();
     forwardAccelerationCommand =
         Vector3.ClampMagnitude(forwardAccelerationCommand, maxForwardAcceleration);
-    float maxNormalAcceleration = CalculateMaxAcceleration();
+    float maxNormalAcceleration = CalculateMaxNormalAcceleration();
     normalAccelerationCommand =
         Vector3.ClampMagnitude(normalAccelerationCommand, maxNormalAcceleration);
     accelerationCommand = forwardAccelerationCommand + normalAccelerationCommand;

--- a/Assets/Scripts/Threats/Threat.cs
+++ b/Assets/Scripts/Threats/Threat.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public abstract class Threat : Agent {
-
   protected AttackBehavior _attackBehavior;
   [SerializeField]
   protected Vector3 _currentWaypoint;
@@ -14,25 +13,25 @@ public abstract class Threat : Agent {
 
   public void SetAttackBehavior(AttackBehavior attackBehavior) {
     _attackBehavior = attackBehavior;
-    _target = SimManager.Instance.CreateDummyThreat(attackBehavior.targetPosition, attackBehavior.targetVelocity);
+    _target = SimManager.Instance.CreateDummyThreat(attackBehavior.targetPosition,
+                                                    attackBehavior.targetVelocity);
   }
 
   protected float PowerTableLookup(PowerSetting powerSetting) {
-    switch (powerSetting)
-    {
-        case PowerSetting.IDLE:
-            return _staticAgentConfig.powerTable.IDLE;
-        case PowerSetting.LOW:
-            return _staticAgentConfig.powerTable.LOW;
-        case PowerSetting.CRUISE:
-            return _staticAgentConfig.powerTable.CRUISE;
-        case PowerSetting.MIL:
-            return _staticAgentConfig.powerTable.MIL;
-        case PowerSetting.MAX:
-            return _staticAgentConfig.powerTable.MAX;
-        default:
-            Debug.LogError("Invalid power setting");
-            return 0f;
+    switch (powerSetting) {
+      case PowerSetting.IDLE:
+        return _staticAgentConfig.powerTable.IDLE;
+      case PowerSetting.LOW:
+        return _staticAgentConfig.powerTable.LOW;
+      case PowerSetting.CRUISE:
+        return _staticAgentConfig.powerTable.CRUISE;
+      case PowerSetting.MIL:
+        return _staticAgentConfig.powerTable.MIL;
+      case PowerSetting.MAX:
+        return _staticAgentConfig.powerTable.MAX;
+      default:
+        Debug.LogError("Invalid power setting");
+        return 0f;
     }
   }
 

--- a/Assets/StreamingAssets/Configs/Models/Interceptors/hydra70.json
+++ b/Assets/StreamingAssets/Configs/Models/Interceptors/hydra70.json
@@ -19,9 +19,5 @@
         "crossSectionalArea": 0.004,
         "finArea": 0.007,
         "bodyArea": 0.12
-    },
-    "hitConfig": {
-        "hitRadius": 1,
-        "killProbability": 0.9
     }
 }

--- a/Assets/StreamingAssets/Configs/Models/Interceptors/hydra70.json
+++ b/Assets/StreamingAssets/Configs/Models/Interceptors/hydra70.json
@@ -2,7 +2,7 @@
     "name": "Hydra 70",
     "agentClass": "CarrierInterceptor",
     "accelerationConfig": {
-        "maxReferenceAcceleration": 300,
+        "maxReferenceNormalAcceleration": 300,
         "referenceSpeed": 1000,
         "maxForwardAcceleration": 0
     },

--- a/Assets/StreamingAssets/Configs/Models/Interceptors/hydra70.json
+++ b/Assets/StreamingAssets/Configs/Models/Interceptors/hydra70.json
@@ -3,7 +3,8 @@
     "agentClass": "CarrierInterceptor",
     "accelerationConfig": {
         "maxReferenceAcceleration": 300,
-        "referenceSpeed": 1000
+        "referenceSpeed": 1000,
+        "maxForwardAcceleration": 0
     },
     "boostConfig": {
         "boostTime": 0.3,

--- a/Assets/StreamingAssets/Configs/Models/Interceptors/micromissile.json
+++ b/Assets/StreamingAssets/Configs/Models/Interceptors/micromissile.json
@@ -2,7 +2,7 @@
     "name": "Micromissile",
     "agentClass": "MissileInterceptor",
     "accelerationConfig": {
-        "maxReferenceAcceleration": 300,
+        "maxReferenceNormalAcceleration": 300,
         "referenceSpeed": 1000,
         "maxForwardAcceleration": 0
     },

--- a/Assets/StreamingAssets/Configs/Models/Interceptors/micromissile.json
+++ b/Assets/StreamingAssets/Configs/Models/Interceptors/micromissile.json
@@ -1,27 +1,23 @@
 {
-  "name": "Micromissile",
-  "agentClass": "MissileInterceptor",
-  "accelerationConfig": {
-    "maxReferenceAcceleration": 300,
-    "referenceSpeed": 1000
-  },
-  "boostConfig": {
-    "boostTime": 0.3,
-    "boostAcceleration": 350
-  },
-  "liftDragConfig": {
-    "liftCoefficient": 0.2,
-    "dragCoefficient": 0.7,
-    "liftDragRatio": 5
-  },
-  "bodyConfig": {
-    "mass": 0.37,
-    "crossSectionalArea": 0.0003,
-    "finArea": 0.0006,
-    "bodyArea": 0.01
-  },
-  "hitConfig": {
-    "hitRadius": 1,
-    "killProbability": 0.9
-  }
+    "name": "Micromissile",
+    "agentClass": "MissileInterceptor",
+    "accelerationConfig": {
+        "maxReferenceAcceleration": 300,
+        "referenceSpeed": 1000
+    },
+    "boostConfig": {
+        "boostTime": 0.3,
+        "boostAcceleration": 350
+    },
+    "liftDragConfig": {
+        "liftCoefficient": 0.2,
+        "dragCoefficient": 0.7,
+        "liftDragRatio": 5
+    },
+    "bodyConfig": {
+        "mass": 0.37,
+        "crossSectionalArea": 0.0003,
+        "finArea": 0.0006,
+        "bodyArea": 0.01
+    }
 }

--- a/Assets/StreamingAssets/Configs/Models/Interceptors/micromissile.json
+++ b/Assets/StreamingAssets/Configs/Models/Interceptors/micromissile.json
@@ -3,7 +3,8 @@
     "agentClass": "MissileInterceptor",
     "accelerationConfig": {
         "maxReferenceAcceleration": 300,
-        "referenceSpeed": 1000
+        "referenceSpeed": 1000,
+        "maxForwardAcceleration": 0
     },
     "boostConfig": {
         "boostTime": 0.3,

--- a/Assets/StreamingAssets/Configs/Models/Threats/quadcopter.json
+++ b/Assets/StreamingAssets/Configs/Models/Threats/quadcopter.json
@@ -9,6 +9,9 @@
     "boostConfig": {
         "boostTime": 0
     },
+    "liftDragConfig": {
+      "dragCoefficient": 0
+    },
     "bodyConfig": {
         "mass": 1
     },

--- a/Assets/StreamingAssets/Configs/Models/Threats/quadcopter.json
+++ b/Assets/StreamingAssets/Configs/Models/Threats/quadcopter.json
@@ -3,7 +3,8 @@
     "agentClass": "RotaryWingThreat",
     "accelerationConfig": {
         "maxReferenceAcceleration": 300,
-        "referenceSpeed": 1000
+        "referenceSpeed": 1000,
+        "maxForwardAcceleration": 50
     },
     "boostConfig": {
         "boostTime": 0

--- a/Assets/StreamingAssets/Configs/Models/Threats/quadcopter.json
+++ b/Assets/StreamingAssets/Configs/Models/Threats/quadcopter.json
@@ -2,33 +2,24 @@
     "name": "Quadcopter",
     "agentClass": "RotaryWingThreat",
     "accelerationConfig": {
-      "maxReferenceAcceleration": 300,
-      "referenceSpeed": 1000
+        "maxReferenceAcceleration": 300,
+        "referenceSpeed": 1000
     },
     "boostConfig": {
-      "boostTime": 0.3,
-      "boostAcceleration": 350
-    },
-    "liftDragConfig": {
-      "liftCoefficient": 0.2,
-      "dragCoefficient": 0.7,
-      "liftDragRatio": 5
+        "boostTime": 0
     },
     "bodyConfig": {
-      "mass": 0.37,
-      "crossSectionalArea": 0.0003,
-      "finArea": 0.0006,
-      "bodyArea": 0.01
+        "mass": 1
     },
     "hitConfig": {
-      "hitRadius": 1,
-      "killProbability": 0.9
+        "hitRadius": 1,
+        "killProbability": 0.9
     },
     "powerTable": {
-        "IDLE": 0,
-        "LOW": 20,
-        "CRUISE": 40,
-        "MIL": 50,
-        "MAX": 75
+            "IDLE": 0,
+            "LOW": 20,
+            "CRUISE": 40,
+            "MIL": 50,
+            "MAX": 75
     }
 }

--- a/Assets/StreamingAssets/Configs/Models/Threats/quadcopter.json
+++ b/Assets/StreamingAssets/Configs/Models/Threats/quadcopter.json
@@ -2,7 +2,7 @@
     "name": "Quadcopter",
     "agentClass": "RotaryWingThreat",
     "accelerationConfig": {
-        "maxReferenceAcceleration": 300,
+        "maxReferenceNormalAcceleration": 300,
         "referenceSpeed": 1000,
         "maxForwardAcceleration": 50
     },

--- a/Assets/StreamingAssets/Configs/Models/Threats/ucav.json
+++ b/Assets/StreamingAssets/Configs/Models/Threats/ucav.json
@@ -3,7 +3,8 @@
     "agentClass": "FixedWingThreat",
     "accelerationConfig": {
         "maxReferenceAcceleration": 300,
-        "referenceSpeed": 1000
+        "referenceSpeed": 1000,
+        "maxForwardAcceleration": 50
     },
     "boostConfig": {
         "boostTime": 0

--- a/Assets/StreamingAssets/Configs/Models/Threats/ucav.json
+++ b/Assets/StreamingAssets/Configs/Models/Threats/ucav.json
@@ -2,7 +2,7 @@
     "name": "UCAV",
     "agentClass": "FixedWingThreat",
     "accelerationConfig": {
-        "maxReferenceAcceleration": 300,
+        "maxReferenceNormalAcceleration": 300,
         "referenceSpeed": 1000,
         "maxForwardAcceleration": 50
     },

--- a/Assets/StreamingAssets/Configs/Models/Threats/ucav.json
+++ b/Assets/StreamingAssets/Configs/Models/Threats/ucav.json
@@ -9,6 +9,9 @@
     "boostConfig": {
         "boostTime": 0
     },
+    "liftDragConfig": {
+      "dragCoefficient": 0
+    },
     "bodyConfig": {
         "mass": 10
     },

--- a/Assets/StreamingAssets/Configs/Models/Threats/ucav.json
+++ b/Assets/StreamingAssets/Configs/Models/Threats/ucav.json
@@ -2,33 +2,24 @@
     "name": "UCAV",
     "agentClass": "FixedWingThreat",
     "accelerationConfig": {
-      "maxReferenceAcceleration": 300,
-      "referenceSpeed": 1000
+        "maxReferenceAcceleration": 300,
+        "referenceSpeed": 1000
     },
     "boostConfig": {
-      "boostTime": 0.3,
-      "boostAcceleration": 350
-    },
-    "liftDragConfig": {
-      "liftCoefficient": 0.2,
-      "dragCoefficient": 0.7,
-      "liftDragRatio": 5
+        "boostTime": 0
     },
     "bodyConfig": {
-      "mass": 0.37,
-      "crossSectionalArea": 0.0003,
-      "finArea": 0.0006,
-      "bodyArea": 0.01
+        "mass": 10
     },
     "hitConfig": {
-      "hitRadius": 1,
-      "killProbability": 0.9
+        "hitRadius": 1,
+        "killProbability": 0.9
     },
     "powerTable": {
-        "IDLE": 0,
-        "LOW": 40,
-        "CRUISE": 80,
-        "MIL": 100,
-        "MAX": 120
+            "IDLE": 0,
+            "LOW": 40,
+            "CRUISE": 80,
+            "MIL": 100,
+            "MAX": 120
     }
 }

--- a/Assets/Tests/EditMode/ThreatTests.cs
+++ b/Assets/Tests/EditMode/ThreatTests.cs
@@ -4,12 +4,13 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
-public class ThreatTests : AgentTestBase
-{
-    private FixedWingThreat fixedWingThreat;
-    private RotaryWingThreat rotaryWingThreat;
 
-    private const string TestDirectAttackJson = @"
+public class ThreatTests : AgentTestBase {
+  private FixedWingThreat fixedWingThreat;
+  private RotaryWingThreat rotaryWingThreat;
+
+  private const string TestDirectAttackJson =
+      @"
     {
         ""name"": ""TestDirectAttack"",
         ""attackBehaviorType"": ""DIRECT_ATTACK"",
@@ -46,251 +47,260 @@ public class ThreatTests : AgentTestBase
     }
     ";
 
-    public override void Setup()
-    {
-        base.Setup();
-        // Write the hard-coded JSON to the file
-        string attackConfigPath = Path.Combine(Application.streamingAssetsPath, "Configs/Behaviors/Attack/test_direct_attack.json");
-        Directory.CreateDirectory(Path.GetDirectoryName(attackConfigPath));
-        File.WriteAllText(attackConfigPath, TestDirectAttackJson);
-        // Load configurations using ConfigLoader
-        // Create dynamic configurations for threats
-        var ucavConfig = new DynamicAgentConfig
-        {
-            agent_model = "ucav.json",
-            attack_behavior = "test_direct_attack.json",
-            initial_state = new InitialState
-            {
-                position = new Vector3(2000, 100, 4000),
-                rotation = new Vector3(90, 0, 0),
-                velocity = new Vector3(-50, 0, -100)
-            },
-            standard_deviation = new StandardDeviation
-            {
-                position = new Vector3(400, 30, 400),
-                velocity = new Vector3(0, 0, 15)
-            },
-            dynamic_config = new DynamicConfig
-            {
-                launch_config = new LaunchConfig { launch_time = 0 },
-                sensor_config = new SensorConfig { type = SensorType.IDEAL, frequency = 100 }
-            }
-        };
+  public override void Setup() {
+    base.Setup();
+    // Write the hard-coded JSON to the file
+    string attackConfigPath = Path.Combine(Application.streamingAssetsPath,
+                                           "Configs/Behaviors/Attack/test_direct_attack.json");
+    Directory.CreateDirectory(Path.GetDirectoryName(attackConfigPath));
+    File.WriteAllText(attackConfigPath, TestDirectAttackJson);
+    // Load configurations using ConfigLoader
+    // Create dynamic configurations for threats
+    var ucavConfig = new DynamicAgentConfig {
+      agent_model = "ucav.json", attack_behavior = "test_direct_attack.json",
+      initial_state = new InitialState { position = new Vector3(2000, 100, 4000),
+                                         rotation = new Vector3(90, 0, 0),
+                                         velocity = new Vector3(-50, 0, -100) },
+      standard_deviation = new StandardDeviation { position = new Vector3(400, 30, 400),
+                                                   velocity = new Vector3(0, 0, 15) },
+      dynamic_config =
+          new DynamicConfig { launch_config = new LaunchConfig { launch_time = 0 },
+                              sensor_config =
+                                  new SensorConfig { type = SensorType.IDEAL, frequency = 100 } }
+    };
 
-        var quadcopterConfig = new DynamicAgentConfig
-        {
-            agent_model = "quadcopter.json",
-            attack_behavior = "test_direct_attack.json",
-            initial_state = new InitialState
-            {
-                position = new Vector3(0, 600, 6000),
-                rotation = new Vector3(90, 0, 0),
-                velocity = new Vector3(0, 0, -50)
-            },
-            standard_deviation = new StandardDeviation
-            {
-                position = new Vector3(1000, 200, 100),
-                velocity = new Vector3(0, 0, 25)
-            },
-            dynamic_config = new DynamicConfig
-            {
-                launch_config = new LaunchConfig { launch_time = 0 },
-                sensor_config = new SensorConfig { type = SensorType.IDEAL, frequency = 100 }
-            }
-        };
+    var quadcopterConfig = new DynamicAgentConfig {
+      agent_model = "quadcopter.json", attack_behavior = "test_direct_attack.json",
+      initial_state =
+          new InitialState { position = new Vector3(0, 600, 6000), rotation = new Vector3(90, 0, 0),
+                             velocity = new Vector3(0, 0, -50) },
+      standard_deviation = new StandardDeviation { position = new Vector3(1000, 200, 100),
+                                                   velocity = new Vector3(0, 0, 25) },
+      dynamic_config =
+          new DynamicConfig { launch_config = new LaunchConfig { launch_time = 0 },
+                              sensor_config =
+                                  new SensorConfig { type = SensorType.IDEAL, frequency = 100 } }
+    };
 
+    Agent threatAgent = CreateTestThreat(ucavConfig);
+    Assert.IsNotNull(threatAgent);
+    Assert.IsTrue(threatAgent is FixedWingThreat);
+    fixedWingThreat = (FixedWingThreat)threatAgent;
+    Assert.IsNotNull(fixedWingThreat);
 
-        Agent threatAgent = CreateTestThreat(ucavConfig);
-        Assert.IsNotNull(threatAgent);
-        Assert.IsTrue(threatAgent is FixedWingThreat);
-        fixedWingThreat = (FixedWingThreat)threatAgent;
-        Assert.IsNotNull(fixedWingThreat);
+    threatAgent = CreateTestThreat(quadcopterConfig);
+    Assert.IsNotNull(threatAgent);
+    Assert.IsTrue(threatAgent is RotaryWingThreat);
+    rotaryWingThreat = (RotaryWingThreat)threatAgent;
+    Assert.IsNotNull(rotaryWingThreat);
+  }
 
-        threatAgent = CreateTestThreat(quadcopterConfig);
-        Assert.IsNotNull(threatAgent);
-        Assert.IsTrue(threatAgent is RotaryWingThreat);
-        rotaryWingThreat = (RotaryWingThreat)threatAgent;
-        Assert.IsNotNull(rotaryWingThreat);
+  public override void Teardown() {
+    base.Teardown();
+    // Delete the attack configuration file
+    string attackConfigPath = Path.Combine(Application.streamingAssetsPath,
+                                           "Configs/Behaviors/Attack/test_direct_attack.json");
+    if (File.Exists(attackConfigPath)) {
+      File.Delete(attackConfigPath);
     }
 
-    public override void Teardown()
-    {
-        base.Teardown();
-         // Delete the attack configuration file
-        string attackConfigPath = Path.Combine(Application.streamingAssetsPath, "Configs/Behaviors/Attack/test_direct_attack.json");
-        if (File.Exists(attackConfigPath))
-        {
-            File.Delete(attackConfigPath);
-        }
-
-
-        if (fixedWingThreat != null)
-        {
-            GameObject.DestroyImmediate(fixedWingThreat.gameObject);
-        }
-
-        if (rotaryWingThreat != null)
-        {
-            GameObject.DestroyImmediate(rotaryWingThreat.gameObject);
-        }
+    if (fixedWingThreat != null) {
+      GameObject.DestroyImmediate(fixedWingThreat.gameObject);
     }
 
-    [Test]
-    public void TestDirectAttack_LoadedCorrectly()
-    {
-        // Arrange
-        try 
-        {
-            // Act
-            DynamicAgentConfig config = new DynamicAgentConfig
-            {
-                agent_model = "ucav.json",
-                attack_behavior = "test_direct_attack.json",
-                initial_state = new InitialState(),
-                standard_deviation = new StandardDeviation(),
-                dynamic_config = new DynamicConfig()
-            };
+    if (rotaryWingThreat != null) {
+      GameObject.DestroyImmediate(rotaryWingThreat.gameObject);
+    }
+  }
 
-            Threat threat = CreateTestThreat(config);
+  [Test]
+  public void TestDirectAttack_LoadedCorrectly() {
+    // Arrange
+    try {
+      // Act
+      DynamicAgentConfig config = new DynamicAgentConfig {
+        agent_model = "ucav.json", attack_behavior = "test_direct_attack.json",
+        initial_state = new InitialState(), standard_deviation = new StandardDeviation(),
+        dynamic_config = new DynamicConfig()
+      };
 
-            // Assert
-            Assert.IsNotNull(threat, "Threat should not be null");
+      Threat threat = CreateTestThreat(config);
 
-            AttackBehavior attackBehavior = GetPrivateField<AttackBehavior>(threat, "_attackBehavior");
-            Assert.IsNotNull(attackBehavior, "Attack behavior should not be null");
-            Assert.AreEqual("TestDirectAttack", attackBehavior.name);
-            Assert.AreEqual(AttackBehavior.AttackBehaviorType.DIRECT_ATTACK, attackBehavior.attackBehaviorType);
+      // Assert
+      Assert.IsNotNull(threat, "Threat should not be null");
 
-            Assert.IsTrue(attackBehavior is DirectAttackBehavior, "Attack behavior should be a DirectAttackBehavior");
-            DirectAttackBehavior directAttackBehavior = (DirectAttackBehavior)attackBehavior;
+      AttackBehavior attackBehavior = GetPrivateField<AttackBehavior>(threat, "_attackBehavior");
+      Assert.IsNotNull(attackBehavior, "Attack behavior should not be null");
+      Assert.AreEqual("TestDirectAttack", attackBehavior.name);
+      Assert.AreEqual(AttackBehavior.AttackBehaviorType.DIRECT_ATTACK,
+                      attackBehavior.attackBehaviorType);
 
-            Vector3 targetPosition = directAttackBehavior.targetPosition;
-            Assert.AreEqual(new Vector3(0.01f, 0, 0), targetPosition);
+      Assert.IsTrue(attackBehavior is DirectAttackBehavior,
+                    "Attack behavior should be a DirectAttackBehavior");
+      DirectAttackBehavior directAttackBehavior = (DirectAttackBehavior)attackBehavior;
 
-            DTTFlightPlan flightPlan = directAttackBehavior.flightPlan;
-            Assert.IsNotNull(flightPlan, "Flight plan should not be null");
-            Assert.AreEqual("DistanceToTarget", flightPlan.type);
+      Vector3 targetPosition = directAttackBehavior.targetPosition;
+      Assert.AreEqual(new Vector3(0.01f, 0, 0), targetPosition);
 
+      DTTFlightPlan flightPlan = directAttackBehavior.flightPlan;
+      Assert.IsNotNull(flightPlan, "Flight plan should not be null");
+      Assert.AreEqual("DistanceToTarget", flightPlan.type);
 
-            List<DTTWaypoint> dttWaypoints = flightPlan.waypoints;
-            Assert.IsNotNull(dttWaypoints, "Waypoints should not be null");
-            Assert.AreEqual(2, dttWaypoints.Count, "There should be 2 waypoints");
+      List<DTTWaypoint> dttWaypoints = flightPlan.waypoints;
+      Assert.IsNotNull(dttWaypoints, "Waypoints should not be null");
+      Assert.AreEqual(2, dttWaypoints.Count, "There should be 2 waypoints");
 
-            Assert.AreEqual(5000f, dttWaypoints[0].distance);
-            Assert.AreEqual(100f, dttWaypoints[0].altitude);
-            Assert.AreEqual(PowerSetting.MAX, dttWaypoints[0].power);
+      Assert.AreEqual(5000f, dttWaypoints[0].distance);
+      Assert.AreEqual(100f, dttWaypoints[0].altitude);
+      Assert.AreEqual(PowerSetting.MAX, dttWaypoints[0].power);
 
-            Assert.AreEqual(10000f, dttWaypoints[1].distance);
-            Assert.AreEqual(500f, dttWaypoints[1].altitude);
-            Assert.AreEqual(PowerSetting.MIL, dttWaypoints[1].power);
+      Assert.AreEqual(10000f, dttWaypoints[1].distance);
+      Assert.AreEqual(500f, dttWaypoints[1].altitude);
+      Assert.AreEqual(PowerSetting.MIL, dttWaypoints[1].power);
 
-            // Check targetVelocity
-            Vector3 targetVelocity = directAttackBehavior.targetVelocity;
-            Assert.AreEqual(new Vector3(0.0001f, 0f, 0f), targetVelocity, "Target velocity should match the config");
+      // Check targetVelocity
+      Vector3 targetVelocity = directAttackBehavior.targetVelocity;
+      Assert.AreEqual(new Vector3(0.0001f, 0f, 0f), targetVelocity,
+                      "Target velocity should match the config");
 
-            // Check targetColliderSize
-            Vector3 targetColliderSize = directAttackBehavior.targetColliderSize;
-            Assert.AreEqual(new Vector3(20f, 20f, 20f), targetColliderSize, "Target collider size should match the config");
+      // Check targetColliderSize
+      Vector3 targetColliderSize = directAttackBehavior.targetColliderSize;
+      Assert.AreEqual(new Vector3(20f, 20f, 20f), targetColliderSize,
+                      "Target collider size should match the config");
 
-            // Check targetPosition (more precise check)
-            Assert.AreEqual(0.01f, targetPosition.x, 0.0001f, "Target position X should be 0.01");
-            Assert.AreEqual(0f, targetPosition.y, 0.0001f, "Target position Y should be 0");
-            Assert.AreEqual(0f, targetPosition.z, 0.0001f, "Target position Z should be 0");
+      // Check targetPosition (more precise check)
+      Assert.AreEqual(0.01f, targetPosition.x, 0.0001f, "Target position X should be 0.01");
+      Assert.AreEqual(0f, targetPosition.y, 0.0001f, "Target position Y should be 0");
+      Assert.AreEqual(0f, targetPosition.z, 0.0001f, "Target position Z should be 0");
 
-            // Clean up
-            GameObject.DestroyImmediate(simManager.gameObject);
-        }
-        catch (AssertionException e)
-        {
-            throw new AssertionException(e.Message + "\n" +
-            "This test likely failed because you have edited " +
-            "The test string at the top of the test. Please update the test with the new values.\n" +
-            "If you need to change the test values, please update the test string at the top of the test.");
-        }
+      // Clean up
+      GameObject.DestroyImmediate(simManager.gameObject);
+    } catch (AssertionException e) {
+      throw new AssertionException(
+          e.Message + "\n" + "This test likely failed because you have edited " +
+          "The test string at the top of the test. Please update the test with the new values.\n" +
+          "If you need to change the test values, please update the test string at the top of the test.");
+    }
+  }
+
+  [Test]
+  public void Threat_IsNotAssignable() {
+    Assert.IsFalse(fixedWingThreat.IsAssignable());
+    Assert.IsFalse(rotaryWingThreat.IsAssignable());
+  }
+
+  [Test]
+  public void FixedWingThreat_CalculateAccelerationCommand_RespectsMaxForwardAcceleration() {
+    SetPrivateField(fixedWingThreat, "_currentWaypoint", Vector3.one * 1000f);
+    SensorOutput sensorOutput =
+        fixedWingThreat.GetComponent<Sensor>().SenseWaypoint(Vector3.one * 1000f);
+    Vector3 acceleration =
+        InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationCommand", sensorOutput);
+    float maxForwardAcceleration =
+        InvokePrivateMethod<float>(fixedWingThreat, "CalculateMaxForwardAcceleration");
+    Assert.LessOrEqual((Vector3.Project(acceleration, fixedWingThreat.transform.forward)).magnitude,
+                       maxForwardAcceleration);
+  }
+
+  [Test]
+  public void FixedWingThreat_CalculateAccelerationCommand_RespectsMaxNormalAcceleration() {
+    SetPrivateField(fixedWingThreat, "_currentWaypoint", Vector3.one * 1000f);
+    SensorOutput sensorOutput =
+        fixedWingThreat.GetComponent<Sensor>().SenseWaypoint(Vector3.one * 1000f);
+    Vector3 acceleration =
+        InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationCommand", sensorOutput);
+    float maxNormalAcceleration =
+        InvokePrivateMethod<float>(fixedWingThreat, "CalculateMaxNormalAcceleration");
+    Assert.LessOrEqual(
+        (acceleration - Vector3.Project(acceleration, fixedWingThreat.transform.forward)).magnitude,
+        maxNormalAcceleration);
+  }
+
+  [Test]
+  public void RotaryWingThreat_CalculateAccelerationToWaypoint_RespectsMaxForwardAcceleration() {
+    SetPrivateField(rotaryWingThreat, "_currentWaypoint", Vector3.one * 1000f);
+    Vector3 acceleration =
+        InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
+    float maxForwardAcceleration =
+        InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxForwardAcceleration");
+    Assert.LessOrEqual((Vector3.Project(acceleration, fixedWingThreat.transform.forward)).magnitude,
+                       maxForwardAcceleration);
+  }
+
+  [Test]
+  public void RotaryWingThreat_CalculateAccelerationToWaypoint_RespectsMaxNormalAcceleration() {
+    SetPrivateField(rotaryWingThreat, "_currentWaypoint", Vector3.one * 1000f);
+    Vector3 acceleration =
+        InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
+    float maxNormalAcceleration =
+        InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxNormalAcceleration");
+    Assert.LessOrEqual(
+        (acceleration - Vector3.Project(acceleration, fixedWingThreat.transform.forward)).magnitude,
+        maxNormalAcceleration);
+  }
+
+  private class MockAttackBehavior : AttackBehavior {
+    private Vector3 waypoint;
+    private PowerSetting powerSetting;
+
+    public MockAttackBehavior(Vector3 waypoint, PowerSetting powerSetting) {
+      this.waypoint = waypoint;
+      this.powerSetting = powerSetting;
+      this.name = "MockAttackBehavior";
     }
 
-    [Test]
-    public void Threat_IsNotAssignable()
-    {
-        Assert.IsFalse(fixedWingThreat.IsAssignable());
-        Assert.IsFalse(rotaryWingThreat.IsAssignable());
+    public override (Vector3, PowerSetting)
+        GetNextWaypoint(Vector3 currentPosition, Vector3 targetPosition) {
+      return (waypoint, powerSetting);
     }
+  }
 
-    [Test]
-    public void FixedWingThreat_CalculateAccelerationCommand_RespectsMaxAcceleration()
-    {
-        SetPrivateField(fixedWingThreat, "_currentWaypoint", Vector3.one * 1000f);
-        SensorOutput sensorOutput = fixedWingThreat.GetComponent<Sensor>().SenseWaypoint(Vector3.one * 1000f);
-        Vector3 acceleration = InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationCommand", sensorOutput);
-        float maxAcceleration = InvokePrivateMethod<float>(fixedWingThreat, "CalculateMaxAcceleration");
-        Assert.LessOrEqual(acceleration.magnitude, maxAcceleration);
-    }
+  [Test]
+  public void RotaryWingThreat_CalculateAccelerationToWaypoint_ComputesCorrectly() {
+    // Arrange
+    Vector3 initialPosition = new Vector3(0, 0, 0);
+    Vector3 waypoint = new Vector3(1000, 0, 0);
+    Vector3 initialVelocity = new Vector3(0, 0, 0);
+    float desiredSpeed = 50f;
 
-    [Test]
-    public void RotaryWingThreat_CalculateAccelerationToWaypoint_RespectsMaxAcceleration()
-    {
-        SetPrivateField(rotaryWingThreat, "_currentWaypoint", Vector3.one * 1000f);
-        Vector3 acceleration = InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
-        float maxAcceleration = InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxAcceleration");
-        Assert.LessOrEqual(acceleration.magnitude, maxAcceleration);
-    }
+    rotaryWingThreat.transform.position = initialPosition;
+    SetPrivateField(rotaryWingThreat, "_currentWaypoint", waypoint);
+    SetVelocity(rotaryWingThreat, initialVelocity);
+    SetPrivateField(rotaryWingThreat, "_currentPowerSetting", PowerSetting.MIL);
 
-    private class MockAttackBehavior : AttackBehavior
-    {
-        private Vector3 waypoint;
-        private PowerSetting powerSetting;
+    // Assume PowerTableLookup returns 50 for PowerSetting.MIL
+    // Assert that its true using PowerTableLookup
+    float powerSetting =
+        InvokePrivateMethod<float>(rotaryWingThreat, "PowerTableLookup", PowerSetting.MIL);
+    Assert.AreEqual(desiredSpeed, powerSetting);
 
-        public MockAttackBehavior(Vector3 waypoint, PowerSetting powerSetting)
-        {
-            this.waypoint = waypoint;
-            this.powerSetting = powerSetting;
-            this.name = "MockAttackBehavior";
-        }
+    // Act
+    Vector3 accelerationCommand =
+        InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
 
-        public override (Vector3, PowerSetting) GetNextWaypoint(Vector3 currentPosition, Vector3 targetPosition)
-        {
-            return (waypoint, powerSetting);
-        }
-    }
+    // Assert
+    Vector3 toWaypoint = waypoint - initialPosition;
+    Vector3 expectedAccelerationDir = toWaypoint.normalized;
+    float expectedAccelerationMag = desiredSpeed / (float)Time.fixedDeltaTime;
+    Vector3 expectedAcceleration = expectedAccelerationDir * expectedAccelerationMag;
 
+    // Decompose acceleration into forward and normal acceleration components
+    Vector3 forwardAcceleration =
+        Vector3.Project(expectedAcceleration, rotaryWingThreat.transform.forward);
+    Vector3 normalAcceleration = expectedAcceleration - forwardAcceleration;
 
-    [Test]
-    public void RotaryWingThreat_CalculateAccelerationToWaypoint_ComputesCorrectly()
-    {
-        // Arrange
-        Vector3 initialPosition = new Vector3(0, 0, 0);
-        Vector3 waypoint = new Vector3(1000, 0, 0);
-        Vector3 initialVelocity = new Vector3(0, 0, 0);
-        float desiredSpeed = 50f;
+    // Limit acceleration magnitude
+    float maxForwardAcceleration =
+        InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxForwardAcceleration");
+    forwardAcceleration = Vector3.ClampMagnitude(forwardAcceleration, maxForwardAcceleration);
+    float maxNormalAcceleration =
+        InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxNormalAcceleration");
+    normalAcceleration = Vector3.ClampMagnitude(normalAcceleration, maxNormalAcceleration);
+    expectedAcceleration = forwardAcceleration + normalAcceleration;
 
-        rotaryWingThreat.transform.position = initialPosition;
-        SetPrivateField(rotaryWingThreat, "_currentWaypoint", waypoint);
-        SetVelocity(rotaryWingThreat, initialVelocity);
-        SetPrivateField(rotaryWingThreat, "_currentPowerSetting", PowerSetting.MIL);
-
-        // Assume PowerTableLookup returns 50 for PowerSetting.MIL
-        // Assert that its true using PowerTableLookup
-        float powerSetting = InvokePrivateMethod<float>(rotaryWingThreat, "PowerTableLookup", PowerSetting.MIL);
-        Assert.AreEqual(desiredSpeed, powerSetting);
-
-        // Act
-        Vector3 accelerationCommand = InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
-
-        // Assert
-        Vector3 toWaypoint = waypoint - initialPosition;
-        Vector3 expectedAccelerationDir = toWaypoint.normalized;
-        float expectedAccelerationMag = desiredSpeed / (float)Time.fixedDeltaTime;
-
-        float maxAcceleration = InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxAcceleration");
-        expectedAccelerationMag = Mathf.Min(expectedAccelerationMag, maxAcceleration);
-
-        Vector3 expectedAcceleration = expectedAccelerationDir * expectedAccelerationMag;
-
-        Assert.AreEqual(expectedAcceleration.magnitude, accelerationCommand.magnitude, 0.1f, "Acceleration magnitude should match expected");
-        Assert.AreEqual(expectedAcceleration.normalized, accelerationCommand.normalized, "Acceleration direction should be towards waypoint");
-    }
-
-   
-
-    // Additional tests...
+    Assert.AreEqual(expectedAcceleration.magnitude, accelerationCommand.magnitude, 0.1f,
+                    "Acceleration magnitude should match expected");
+    Assert.AreEqual(expectedAcceleration.normalized, accelerationCommand.normalized,
+                    "Acceleration direction should be towards waypoint");
+  }
 }

--- a/Assets/Tests/PlayMode/ConfigTest.cs
+++ b/Assets/Tests/PlayMode/ConfigTest.cs
@@ -5,26 +5,21 @@ using System.Collections;
 using UnityEngine.SceneManagement;
 using System.IO;
 public class ConfigTest : TestBase {
+  [OneTimeSetUp]
+  public void LoadScene() {
+    SceneManager.LoadScene("Scenes/MainScene");
+  }
 
-    [OneTimeSetUp]
-    public void LoadScene()
-    {
-        SceneManager.LoadScene("Scenes/MainScene");
+  [UnityTest]
+  public IEnumerator TestAllConfigFilesLoad() {
+    string configPath = Path.Combine(Application.streamingAssetsPath, "Configs");
+    string[] jsonFiles = Directory.GetFiles(configPath, "*.json");
+
+    Assert.IsTrue(jsonFiles.Length > 0, "No JSON files found in the Configs directory");
+
+    foreach (string jsonFile in jsonFiles) {
+      yield return new WaitForSeconds(0.1f);
+      SimManager.Instance.LoadNewConfig(jsonFile);
     }
-
-    [UnityTest]
-    public IEnumerator TestAllConfigFilesLoad()
-    {
-        string configPath = Path.Combine(Application.streamingAssetsPath, "Configs");
-        string[] jsonFiles = Directory.GetFiles(configPath, "*.json");
-
-        Assert.IsTrue(jsonFiles.Length > 0, "No JSON files found in the Configs directory");
-
-        foreach (string jsonFile in jsonFiles)
-        {
-            
-            yield return new WaitForSeconds(0.1f);
-            SimManager.Instance.LoadNewConfig(jsonFile);
-        }
-    }
+  }
 }

--- a/docs/Simulation_Config_Guide.md
+++ b/docs/Simulation_Config_Guide.md
@@ -215,8 +215,9 @@ This file defines parameters for the micromissile model.
 ```json:Assets/StreamingAssets/Configs/Models/micromissile.json
 {
   "accelerationConfig": {
-    "maxReferenceAcceleration": 300,
-    "referenceSpeed": 1000
+    "maxReferenceNormalAcceleration": 300,
+    "referenceSpeed": 1000,
+    "maxForwardAcceleration": 0
   },
   "boostConfig": {
     "boostTime": 0.3,
@@ -243,7 +244,7 @@ This file defines parameters for the micromissile model.
 
 You can tweak the parameters in these model files to adjust performance. For example:
 
-- **Increase Acceleration**: Modify `maxReferenceAcceleration` in `accelerationConfig`.
+- **Increase Normal Acceleration**: Modify `maxReferenceNormalAcceleration` in `accelerationConfig`.
 - **Change Mass**: Adjust the `mass` value in `bodyConfig`.
 - **Alter Aerodynamics**: Tweak `liftCoefficient` and `dragCoefficient` in `liftDragConfig`.
 
@@ -289,8 +290,9 @@ For example:
 public class StaticAgentConfig {
   [Serializable]
   public class AccelerationConfig {
-    public float maxReferenceAcceleration = 300f;
+    public float maxReferenceNormalAcceleration = 300f;
     public float referenceSpeed = 1000f;
+    public float maxForwardAcceleration = 50f;
   }
 
   [Serializable]


### PR DESCRIPTION
Currently, agents have a maximum reference acceleration, which refers to the normal acceleration.  This PR introduces a maximum forward acceleration, which is only used by threats currently, that defines the maximum acceleration at which an agent can accelerate or decelerate along its roll axis.