### PR TITLE
[Controls] Add augmented proportional navigation

### DIFF
--- a/Assets/Scripts/Agent.cs
+++ b/Assets/Scripts/Agent.cs
@@ -26,6 +26,7 @@ public abstract class Agent : MonoBehaviour {
 
   [SerializeField]
   protected Agent _target;
+  [SerializeField]
   protected Agent _targetModel;
   protected bool _isHit = false;
   protected bool _isMiss = false;
@@ -159,7 +160,11 @@ public abstract class Agent : MonoBehaviour {
   }
 
   public Vector3 GetAcceleration() {
-    return GetComponent<Rigidbody>().GetAccumulatedForce() / GetComponent<Rigidbody>().mass;
+    return _acceleration;
+  }
+
+  public void SetAcceleration(Vector3 acceleration) {
+    _acceleration = acceleration;
   }
 
   public double GetDynamicPressure() {
@@ -221,7 +226,9 @@ public abstract class Agent : MonoBehaviour {
     }
 
     _velocity = GetVelocity();
-    _acceleration = GetAcceleration();
+    // Store the acceleration because it is set to zero after each simulation step
+    _acceleration =
+        GetComponent<Rigidbody>().GetAccumulatedForce() / GetComponent<Rigidbody>().mass;
   }
 
   protected virtual void AlignWithVelocity() {
@@ -302,7 +309,7 @@ public class DummyAgent : Agent {
   }
 
   protected override void FixedUpdate() {
-    // Do nothing
+    GetComponent<Rigidbody>().AddForce(_acceleration, ForceMode.Acceleration);
   }
 
   protected override void UpdateReady(double deltaTime) {

--- a/Assets/Scripts/Config/SimulationConfig.cs
+++ b/Assets/Scripts/Config/SimulationConfig.cs
@@ -103,6 +103,7 @@ public class SensorConfig {
 
 [Serializable]
 public class FlightConfig {
+  public bool augmentedPnEnabled;
   public bool evasionEnabled;
   public float evasionRangeThreshold;
 }

--- a/Assets/Scripts/Interceptor.cs
+++ b/Assets/Scripts/Interceptor.cs
@@ -103,7 +103,11 @@ public class Interceptor : Agent {
   }
 
   private Vector3 CalculateAccelerationInput(SensorOutput sensorOutput) {
-    // Implement Augmented Proportional Navigation guidance law
+    // TODO(titan): Refactor all controller-related code into a separate controller interface with
+    // subclasses. A controller factory will instantiate the correct controller for each dynamic
+    // configuration.
+
+    // Implement (Augmented) Proportional Navigation guidance law
     Vector3 accelerationInput = Vector3.zero;
 
     // Extract relevant information from sensor output
@@ -128,10 +132,12 @@ public class Interceptor : Agent {
     accelerationInput = transform.right * accAz + transform.up * accEl;
 
     // For Augmented Proportional Navigation, add a feedforward term for the target acceleration
-    Vector3 targetAcceleration = _targetModel.GetAcceleration();
-    Vector3 normalTargetAcceleration =
-        Vector3.ProjectOnPlane(targetAcceleration, transform.forward);
-    accelerationInput += N / 2 * normalTargetAcceleration;
+    if (_dynamicAgentConfig.dynamic_config.flight_config.augmentedPnEnabled) {
+      Vector3 targetAcceleration = _targetModel.GetAcceleration();
+      Vector3 normalTargetAcceleration =
+          Vector3.ProjectOnPlane(targetAcceleration, transform.forward);
+      accelerationInput += N / 2 * normalTargetAcceleration;
+    }
 
     // Clamp the normal acceleration input to the maximum normal acceleration
     float maxNormalAcceleration = CalculateMaxNormalAcceleration();

--- a/Assets/Scripts/Interceptor.cs
+++ b/Assets/Scripts/Interceptor.cs
@@ -132,7 +132,7 @@ public class Interceptor : Agent {
     accelerationInput = transform.right * accAz + transform.up * accEl;
 
     // For Augmented Proportional Navigation, add a feedforward term for the target acceleration
-    if (_dynamicAgentConfig.dynamic_config.flight_config.augmentedPnEnabled) {
+    if (dynamicAgentConfig.dynamic_config.flight_config.augmentedPnEnabled) {
       Vector3 targetAcceleration = _targetModel.GetAcceleration();
       Vector3 normalTargetAcceleration =
           Vector3.ProjectOnPlane(targetAcceleration, transform.forward);

--- a/Assets/Scripts/Interceptor.cs
+++ b/Assets/Scripts/Interceptor.cs
@@ -86,7 +86,7 @@ public class Interceptor : Agent {
     }
 
     _sensorOutput = GetComponent<Sensor>().Sense(_targetModel);
-    return CalculateAccelerationCommand(_sensorOutput);
+    return CalculateAccelerationInput(_sensorOutput);
   }
 
   private void UpdateTargetModel(double deltaTime) {
@@ -102,25 +102,25 @@ public class Interceptor : Agent {
     }
   }
 
-  private Vector3 CalculateAccelerationCommand(SensorOutput sensorOutput) {
-    // Implement Proportional Navigation guidance law
-    Vector3 accelerationCommand = Vector3.zero;
+  private Vector3 CalculateAccelerationInput(SensorOutput sensorOutput) {
+    // Implement Augmented Proportional Navigation guidance law
+    Vector3 accelerationInput = Vector3.zero;
 
     // Extract relevant information from sensor output
     float losRateAz = sensorOutput.velocity.azimuth;
     float losRateEl = sensorOutput.velocity.elevation;
-    float closing_velocity =
+    float closingVelocity =
         -sensorOutput.velocity
              .range;  // Negative because closing velocity is opposite to range rate
 
     // Navigation gain (adjust as needed)
     float N = _navigationGain;
     // Normal PN guidance for positive closing velocity
-    float turnFactor = closing_velocity;
+    float turnFactor = closingVelocity;
     // Handle negative closing velocity scenario
-    if (closing_velocity < 0) {
+    if (closingVelocity < 0) {
       // Target is moving away, apply stronger turn
-      turnFactor = Mathf.Max(1f, Mathf.Abs(closing_velocity) * 100f);
+      turnFactor = Mathf.Max(1f, Mathf.Abs(closingVelocity) * 100f);
     }
     float accAz = N * turnFactor * losRateAz;
     float accEl = N * turnFactor * losRateEl;
@@ -136,6 +136,7 @@ public class Interceptor : Agent {
     // Clamp the normal acceleration input to the maximum normal acceleration
     float maxNormalAcceleration = CalculateMaxNormalAcceleration();
     accelerationInput = Vector3.ClampMagnitude(accelerationInput, maxNormalAcceleration);
+    _accelerationInput = accelerationInput;
     return accelerationInput;
   }
 

--- a/Assets/Scripts/Threats/RotaryWingThreat.cs
+++ b/Assets/Scripts/Threats/RotaryWingThreat.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class RotaryWingThreat : Threat {
-  private Vector3 _accelerationCommand;
+  private Vector3 _accelerationInput;
 
   // Start is called before the first frame update
   protected override void Start() {
@@ -44,21 +44,21 @@ public class RotaryWingThreat : Threat {
     Vector3 desiredVelocity = toWaypoint.normalized * desiredSpeed;
 
     // Calculate acceleration needed to reach desired velocity
-    Vector3 accelerationCommand = (desiredVelocity - currentVelocity) / (float)Time.fixedDeltaTime;
-    Vector3 forwardAccelerationCommand = Vector3.Project(accelerationCommand, transform.forward);
-    Vector3 normalAccelerationCommand = accelerationCommand - forwardAccelerationCommand;
+    Vector3 accelerationInput = (desiredVelocity - currentVelocity) / (float)Time.fixedDeltaTime;
+    Vector3 forwardAccelerationInput = Vector3.Project(accelerationInput, transform.forward);
+    Vector3 normalAccelerationInput = accelerationInput - forwardAccelerationInput;
 
     // Limit acceleration magnitude
     float maxForwardAcceleration = CalculateMaxForwardAcceleration();
-    forwardAccelerationCommand =
-        Vector3.ClampMagnitude(forwardAccelerationCommand, maxForwardAcceleration);
+    forwardAccelerationInput =
+        Vector3.ClampMagnitude(forwardAccelerationInput, maxForwardAcceleration);
     float maxNormalAcceleration = CalculateMaxNormalAcceleration();
-    normalAccelerationCommand =
-        Vector3.ClampMagnitude(normalAccelerationCommand, maxNormalAcceleration);
-    accelerationCommand = forwardAccelerationCommand + normalAccelerationCommand;
+    normalAccelerationInput =
+        Vector3.ClampMagnitude(normalAccelerationInput, maxNormalAcceleration);
+    accelerationInput = forwardAccelerationInput + normalAccelerationInput;
 
-    _accelerationCommand = accelerationCommand;  // Store for debugging
-    return accelerationCommand;
+    _accelerationInput = accelerationInput;  // Store for debugging
+    return accelerationInput;
   }
 
   private void ApplyAcceleration(Vector3 acceleration) {
@@ -73,7 +73,7 @@ public class RotaryWingThreat : Threat {
       Gizmos.DrawLine(transform.position, _currentWaypoint);
 
       Gizmos.color = Color.green;
-      Gizmos.DrawRay(transform.position, _accelerationCommand);
+      Gizmos.DrawRay(transform.position, _accelerationInput);
     }
   }
 }

--- a/Assets/StreamingAssets/Configs/1_salvo_1_hydra_7_drones.json
+++ b/Assets/StreamingAssets/Configs/1_salvo_1_hydra_7_drones.json
@@ -19,6 +19,9 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "augmentedPnEnabled": false
           }
         },
         "submunitions_config": {
@@ -40,6 +43,9 @@
               "sensor_config": {
                 "type": "IDEAL",
                 "frequency": 100
+              },
+              "flight_config": {
+                "augmentedPnEnabled": false
               }
             }
           }

--- a/Assets/StreamingAssets/Configs/1_salvo_4_sfrj_10_brahmos.json
+++ b/Assets/StreamingAssets/Configs/1_salvo_4_sfrj_10_brahmos.json
@@ -19,6 +19,9 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "augmentedPnEnabled": false
           }
         },
         "submunitions_config": {
@@ -40,6 +43,9 @@
               "sensor_config": {
                 "type": "IDEAL",
                 "frequency": 100
+              },
+              "flight_config": {
+                "augmentedPnEnabled": false
               }
             }
           }

--- a/Assets/StreamingAssets/Configs/2_salvo_2_hydra_7_quad_3_ucav.json
+++ b/Assets/StreamingAssets/Configs/2_salvo_2_hydra_7_quad_3_ucav.json
@@ -21,7 +21,7 @@
             "frequency": 100
           },
           "flight_config": {
-            "evasionEnabled": false
+            "augmentedPnEnabled": false
           }
         },
         "submunitions_config": {
@@ -45,8 +45,7 @@
                 "frequency": 100
               },
               "flight_config": {
-                "evasionEnabled": true,
-                "evasionRangeThreshold": 1000
+                "augmentedPnEnabled": false
               }
             }
           }
@@ -73,7 +72,7 @@
             "frequency": 100
           },
           "flight_config": {
-            "evasionEnabled": false
+            "augmentedPnEnabled": false
           }
         },
         "submunitions_config": {
@@ -97,8 +96,7 @@
                 "frequency": 100
               },
               "flight_config": {
-                "evasionEnabled": true,
-                "evasionRangeThreshold": 1000
+                "augmentedPnEnabled": false
               }
             }
           }

--- a/Assets/StreamingAssets/Configs/3_salvo_10_hydra_200_drones.json
+++ b/Assets/StreamingAssets/Configs/3_salvo_10_hydra_200_drones.json
@@ -19,6 +19,9 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "augmentedPnEnabled": false
           }
         },
         "submunitions_config": {
@@ -40,6 +43,9 @@
               "sensor_config": {
                 "type": "IDEAL",
                 "frequency": 100
+              },
+              "flight_config": {
+                "augmentedPnEnabled": false
               }
             }
           }
@@ -64,6 +70,9 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "augmentedPnEnabled": false
           }
         },
         "submunitions_config": {
@@ -85,6 +94,9 @@
               "sensor_config": {
                 "type": "IDEAL",
                 "frequency": 100
+              },
+              "flight_config": {
+                "augmentedPnEnabled": false
               }
             }
           }
@@ -109,6 +121,9 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "augmentedPnEnabled": false
           }
         },
         "submunitions_config": {
@@ -130,6 +145,9 @@
               "sensor_config": {
                 "type": "IDEAL",
                 "frequency": 100
+              },
+              "flight_config": {
+                "augmentedPnEnabled": false
               }
             }
           }

--- a/Assets/Tests/EditMode/ThreatTests.cs
+++ b/Assets/Tests/EditMode/ThreatTests.cs
@@ -198,8 +198,9 @@ public class ThreatTests : AgentTestBase {
         InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationInput", sensorOutput);
     float maxForwardAcceleration =
         InvokePrivateMethod<float>(fixedWingThreat, "CalculateMaxForwardAcceleration");
+    const float epsilon = 1e-5f;
     Assert.LessOrEqual((Vector3.Project(acceleration, fixedWingThreat.transform.forward)).magnitude,
-                       maxForwardAcceleration);
+                       maxForwardAcceleration + epsilon);
   }
 
   [Test]
@@ -211,7 +212,10 @@ public class ThreatTests : AgentTestBase {
         InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationInput", sensorOutput);
     float maxNormalAcceleration =
         InvokePrivateMethod<float>(fixedWingThreat, "CalculateMaxNormalAcceleration");
-    Assert.LessOrEqual(acceleration.magnitude, maxNormalAcceleration);
+    const float epsilon = 1e-5f;
+    Assert.LessOrEqual(
+        acceleration.magnitude, maxNormalAcceleration + epsilon,
+        $"Acceleration magnitude {acceleration.magnitude} should be less than or equal to max normal acceleration {maxNormalAcceleration}");
   }
 
   [Test]
@@ -221,8 +225,9 @@ public class ThreatTests : AgentTestBase {
         InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
     float maxForwardAcceleration =
         InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxForwardAcceleration");
+    const float epsilon = 1e-5f;
     Assert.LessOrEqual((Vector3.Project(acceleration, fixedWingThreat.transform.forward)).magnitude,
-                       maxForwardAcceleration);
+                       maxForwardAcceleration + epsilon);
   }
 
   [Test]
@@ -232,9 +237,10 @@ public class ThreatTests : AgentTestBase {
         InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
     float maxNormalAcceleration =
         InvokePrivateMethod<float>(rotaryWingThreat, "CalculateMaxNormalAcceleration");
+    const float epsilon = 1e-5f;
     Assert.LessOrEqual(
         (acceleration - Vector3.Project(acceleration, fixedWingThreat.transform.forward)).magnitude,
-        maxNormalAcceleration);
+        maxNormalAcceleration + epsilon);
   }
 
   private class MockAttackBehavior : AttackBehavior {

--- a/docs/Simulation_Config_Guide.md
+++ b/docs/Simulation_Config_Guide.md
@@ -55,6 +55,9 @@ This is a basic configuration featuring a single salvo with one interceptor type
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "augmentedPnEnabled": false
           }
         },
         "submunitions_config": {
@@ -107,6 +110,9 @@ This configuration demonstrates a more complex scenario with three salvos, each 
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "augmentedPnEnabled": false
           }
         },
         "submunitions_config": {
@@ -147,7 +153,7 @@ The key difference between the examples is that the **Number of Salvos** in `3_s
 Multiple salvos are achieved by:
 
 - Adding multiple configurations in the `interceptor_swarm_configs` array.
-- Specifying different `launch_time` values in the `dynamic_config` for each salvo to control when they launch.
+- Specifying different `launch_time` values in the `launch_config` of the `dynamic_config` for each salvo to control when they launch.
 
 ### Key Configuration Parameters
 
@@ -163,7 +169,7 @@ Multiple salvos are achieved by:
   - **`interceptor_type`** / **`threat_type`**: Defines the type of interceptor or threat.
   - **`initial_state`**: Sets the starting position, rotation, and velocity.
   - **`standard_deviation`**: Adds random noise to initial states for variability.
-  - **`dynamic_config`**: Time-dependent settings like `launch_time` and sensor configurations.
+  - **`dynamic_config`**: Time-dependent settings like launch configurations, sensor configurations, and in-flight configurations.
   - **`submunitions_config`**: Details for any submunitions (e.g., micromissiles deployed by a larger interceptor).
 
 ### Adding or Modifying Agents
@@ -186,7 +192,7 @@ Multiple salvos are achieved by:
    }
    ```
 
-   - **`launch_time`** in `dynamic_config` controls when this swarm (or salvo) is deployed.
+   - **`launch_time`** in `launch_config` controls when this swarm (or salvo) is deployed.
 
 2. **Modify Existing Configurations**:
 
@@ -203,6 +209,7 @@ The `Models` directory contains the following default model configurations:
 - **`micromissile.json`**
 - **`hydra70.json`**
 - **`drone.json`**
+- **`srfj.json`**
 
 These JSON files serve as templates and can be tweaked to modify the behavior of the corresponding models.
 


### PR DESCRIPTION
This PR changes the interceptors to use augmented proportional navigation.  (Dummy agents can't accelerate, so augmented PN isn't enabled for threats).

Does augmented PN help?  Kinda.  Empirically, we see that the interceptors are leading the threats.  We simulated the engagement and modified the threats to be accelerating at 25g towards the asset.  However, we still miss quite a few targets (not sure if this is due to the simulation accuracy from the increased threat acceleration).

Without augmented PN:
![without](https://github.com/user-attachments/assets/e249a1cb-b99f-4f4d-aceb-bbd9bcafc199)

With augmented PN:
![with](https://github.com/user-attachments/assets/b88fa738-bb41-498c-954a-80623d729ed7)
![with_hit](https://github.com/user-attachments/assets/10252b36-015f-46b8-9da0-1327877df0d9)
