### PR TITLE
[Threat] Add preliminary threat evasion from interceptors

### DIFF
--- a/Assets/Scripts/Agent.cs
+++ b/Assets/Scripts/Agent.cs
@@ -37,8 +37,8 @@ public abstract class Agent : MonoBehaviour {
   [SerializeField]
   protected double _timeInPhase = 0;
 
-  public DynamicAgentConfig _dynamicAgentConfig;
   public StaticAgentConfig _staticAgentConfig;
+  public DynamicAgentConfig _dynamicAgentConfig;
 
   // Define delegates
   public delegate void InterceptHitEventHandler(Interceptor interceptor, Threat target);

--- a/Assets/Scripts/Agent.cs
+++ b/Assets/Scripts/Agent.cs
@@ -25,6 +25,8 @@ public abstract class Agent : MonoBehaviour {
   protected float _speed;
 
   [SerializeField]
+  protected List<Agent> _interceptors = new List<Agent>();
+  [SerializeField]
   protected Agent _target;
   protected Agent _targetModel;
   protected bool _isHit = false;
@@ -78,6 +80,7 @@ public abstract class Agent : MonoBehaviour {
 
   public virtual void AssignTarget(Agent target) {
     _target = target;
+    _target.AddInterceptor(this);
     _targetModel = SimManager.Instance.CreateDummyAgent(target.GetPosition(), target.GetVelocity());
   }
 
@@ -100,6 +103,7 @@ public abstract class Agent : MonoBehaviour {
   }
 
   public virtual void UnassignTarget() {
+    _target.RemoveInterceptor(this);
     _target = null;
     _targetModel = null;
   }
@@ -107,6 +111,14 @@ public abstract class Agent : MonoBehaviour {
   // Return whether the agent has hit or been hit.
   public bool IsHit() {
     return _isHit;
+  }
+
+  public void AddInterceptor(Agent interceptor) {
+    _interceptors.Add(interceptor);
+  }
+
+  public void RemoveInterceptor(Agent interceptor) {
+    _interceptors.Remove(interceptor);
   }
 
   public virtual void TerminateAgent() {

--- a/Assets/Scripts/Config/SimulationConfig.cs
+++ b/Assets/Scripts/Config/SimulationConfig.cs
@@ -20,6 +20,7 @@ public class SimulationConfig {
 public class DynamicConfig {
   public LaunchConfig launch_config;
   public SensorConfig sensor_config;
+  public FlightConfig flight_config;
 }
 
 [Serializable]
@@ -101,8 +102,14 @@ public class SensorConfig {
 }
 
 [Serializable]
+public class FlightConfig {
+  public bool evasionEnabled;
+  public float evasionRangeThreshold;
+}
+
+[Serializable]
 public class ThreatConfig {
-  public agentClass threat_class;
+  public AgentClass threat_class;
   public InitialState initial_state;
   public PlottingConfig plotting_config;
   public string prefabName;
@@ -111,7 +118,7 @@ public class ThreatConfig {
 // Enums
 
 [JsonConverter(typeof(StringEnumConverter))]
-public enum agentClass { NONE, FIXEDWING, ROTARYWING, BALLISTIC }
+public enum AgentClass { NONE, FIXEDWING, ROTARYWING, BALLISTIC }
 [JsonConverter(typeof(StringEnumConverter))]
 public enum ConfigColor { BLUE, GREEN, RED }
 [JsonConverter(typeof(StringEnumConverter))]

--- a/Assets/Scripts/Interceptor.cs
+++ b/Assets/Scripts/Interceptor.cs
@@ -114,21 +114,21 @@ public class Interceptor : Agent {
 
     // Navigation gain (adjust as needed)
     float N = _navigationGain;
-    float acc_az = 0;
-    float acc_el = 0;
+    float accAz = 0;
+    float accEl = 0;
     // Handle negative closing velocity scenario
     if (closing_velocity < 0) {
       // Target is moving away, apply stronger turn
       float turnFactor = Mathf.Max(1f, Mathf.Abs(closing_velocity) * 100f);
-      acc_az = N * turnFactor * los_rate_az;
-      acc_el = N * turnFactor * los_rate_el;
+      accAz = N * turnFactor * los_rate_az;
+      accEl = N * turnFactor * los_rate_el;
     } else {
       // Normal PN guidance for positive closing velocity
-      acc_az = N * closing_velocity * los_rate_az;
-      acc_el = N * closing_velocity * los_rate_el;
+      accAz = N * closing_velocity * los_rate_az;
+      accEl = N * closing_velocity * los_rate_el;
     }
     // Convert acceleration commands to craft body frame
-    accelerationCommand = transform.right * acc_az + transform.up * acc_el;
+    accelerationCommand = transform.right * accAz + transform.up * accEl;
 
     // Clamp the normal acceleration command to the maximum normal acceleration
     float maxNormalAcceleration = CalculateMaxNormalAcceleration();

--- a/Assets/Scripts/Threats/FixedWingThreat.cs
+++ b/Assets/Scripts/Threats/FixedWingThreat.cs
@@ -27,9 +27,7 @@ public class FixedWingThreat : Threat {
     _elapsedTime += deltaTime;
     Vector3 accelerationInput = Vector3.zero;
 
-    // Evasion range threshold (can be adjusted)
-    float evasionRangeThreshold = 1000f;
-    if (ShouldEvade(evasionRangeThreshold)) {
+    if (ShouldEvade()) {
       accelerationInput = EvadeInterceptor(GetClosestInterceptor());
     } else if (HasAssignedTarget()) {
       // Update waypoint and power setting

--- a/Assets/Scripts/Threats/FixedWingThreat.cs
+++ b/Assets/Scripts/Threats/FixedWingThreat.cs
@@ -6,7 +6,7 @@ public class FixedWingThreat : Threat {
   [SerializeField]
   private float _navigationGain = 50f;
 
-  private Vector3 _accelerationCommand;
+  private Vector3 _accelerationInput;
   private double _elapsedTime = 0;
 
   // Start is called before the first frame update
@@ -27,7 +27,11 @@ public class FixedWingThreat : Threat {
     _elapsedTime += deltaTime;
     Vector3 accelerationInput = Vector3.zero;
 
-    if (HasAssignedTarget()) {
+    // Evasion range threshold (can be adjusted)
+    float evasionRangeThreshold = 1000f;
+    if (ShouldEvade(evasionRangeThreshold)) {
+      accelerationInput = EvadeInterceptor(GetClosestInterceptor());
+    } else if (HasAssignedTarget()) {
       // Update waypoint and power setting
       UpdateWaypointAndPower();
 
@@ -39,14 +43,14 @@ public class FixedWingThreat : Threat {
         _elapsedTime = 0;
       }
 
-      // Calculate the acceleration input using PN
-      Vector3 pnAcceleration = CalculateAccelerationCommand(_sensorOutput);
+      // Calculate the normal acceleration input using PN
+      Vector3 normalAcceleration = CalculateAccelerationInput(_sensorOutput);
 
-      // Adjust velocity based on power setting
-      Vector3 speedAdjustmentAcceleration = CalculateSpeedAdjustmentAcceleration();
+      // Adjust the speed based on power setting
+      Vector3 forwardAcceleration = CalculateForwardAcceleration();
 
       // Combine the accelerations
-      accelerationInput = pnAcceleration + speedAdjustmentAcceleration;
+      accelerationInput = normalAcceleration + forwardAcceleration;
     }
 
     // Calculate and set the total acceleration
@@ -61,9 +65,9 @@ public class FixedWingThreat : Threat {
         _attackBehavior.GetNextWaypoint(transform.position, _target.transform.position);
   }
 
-  private Vector3 CalculateAccelerationCommand(SensorOutput sensorOutput) {
+  private Vector3 CalculateAccelerationInput(SensorOutput sensorOutput) {
     // Implement Proportional Navigation guidance law
-    Vector3 accelerationCommand = Vector3.zero;
+    Vector3 accelerationInput = Vector3.zero;
 
     // Extract relevant information from sensor output
     float los_rate_az = sensorOutput.velocity.azimuth;
@@ -75,55 +79,19 @@ public class FixedWingThreat : Threat {
     // Navigation gain (adjust as needed)
     float N = _navigationGain;
 
-    // Calculate acceleration commands in azimuth and elevation planes
-    float acc_az = N * closing_velocity * los_rate_az;
-    float acc_el = N * closing_velocity * los_rate_el;
+    // Calculate acceleration inputs in azimuth and elevation planes
+    float accAz = N * closing_velocity * los_rate_az;
+    float accEl = N * closing_velocity * los_rate_el;
 
-    // Convert acceleration commands to craft body frame
-    accelerationCommand = transform.right * acc_az + transform.up * acc_el;
+    // Convert acceleration inputs to craft body frame
+    accelerationInput = transform.right * accAz + transform.up * accEl;
 
-    // Clamp the normal acceleration command to the maximum normal acceleration
+    // Clamp the normal acceleration input to the maximum normal acceleration
     float maxNormalAcceleration = CalculateMaxNormalAcceleration();
-    accelerationCommand = Vector3.ClampMagnitude(accelerationCommand, maxNormalAcceleration);
+    accelerationInput = Vector3.ClampMagnitude(accelerationInput, maxNormalAcceleration);
 
-    // Update the stored acceleration command for debugging
-    _accelerationCommand = accelerationCommand;
-    return accelerationCommand;
-  }
-
-  private Vector3 CalculateSpeedAdjustmentAcceleration() {
-    // Get the target velocity for the current power setting
-    float targetSpeed = PowerTableLookup(_currentPowerSetting);
-
-    // Calculate the current speed
-    float currentSpeed = GetVelocity().magnitude;
-
-    // Speed error
-    float speedError = targetSpeed - currentSpeed;
-
-    // Proportional gain for speed control
-    float speedControlGain = 10.0f;  // Adjust this gain as necessary
-
-    // Desired acceleration to adjust speed
-    float desiredAccelerationMagnitude = speedControlGain * speedError;
-
-    // Limit the desired acceleration
-    float maxForwardAcceleration = CalculateMaxForwardAcceleration();
-    desiredAccelerationMagnitude =
-        Mathf.Clamp(desiredAccelerationMagnitude, -maxForwardAcceleration, maxForwardAcceleration);
-
-    // Acceleration direction (along current velocity direction)
-    Vector3 accelerationDirection = GetVelocity().normalized;
-
-    // Handle zero velocity case
-    if (accelerationDirection.magnitude < 0.1f) {
-      accelerationDirection = transform.forward;  // Default direction
-    }
-
-    // Calculate acceleration vector
-    Vector3 speedAdjustmentAcceleration = accelerationDirection * desiredAccelerationMagnitude;
-
-    return speedAdjustmentAcceleration;
+    _accelerationInput = accelerationInput;
+    return accelerationInput;
   }
 
   // Optional: Add this method to visualize debug information
@@ -133,7 +101,7 @@ public class FixedWingThreat : Threat {
       Gizmos.DrawLine(transform.position, _currentWaypoint);
 
       Gizmos.color = Color.green;
-      Gizmos.DrawRay(transform.position, _accelerationCommand);
+      Gizmos.DrawRay(transform.position, _accelerationInput);
     }
   }
 }

--- a/Assets/Scripts/Threats/RotaryWingThreat.cs
+++ b/Assets/Scripts/Threats/RotaryWingThreat.cs
@@ -22,9 +22,7 @@ public class RotaryWingThreat : Threat {
   protected override void UpdateMidCourse(double deltaTime) {
     Vector3 accelerationInput = Vector3.zero;
 
-    // Evasion range threshold (can be adjusted)
-    float evasionRangeThreshold = 1000f;
-    if (ShouldEvade(evasionRangeThreshold)) {
+    if (ShouldEvade()) {
       accelerationInput = EvadeInterceptor(GetClosestInterceptor());
     } else if (HasAssignedTarget()) {
       // Update waypoint and power setting

--- a/Assets/Scripts/Threats/RotaryWingThreat.cs
+++ b/Assets/Scripts/Threats/RotaryWingThreat.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class RotaryWingThreat : Threat {
-  private Vector3 _accelerationCommand;
+  private Vector3 _accelerationInput;
 
   // Start is called before the first frame update
   protected override void Start() {
@@ -20,14 +20,22 @@ public class RotaryWingThreat : Threat {
   protected override void UpdateBoost(double deltaTime) {}
 
   protected override void UpdateMidCourse(double deltaTime) {
-    if (HasAssignedTarget()) {
+    Vector3 accelerationInput = Vector3.zero;
+
+    // Evasion range threshold (can be adjusted)
+    float evasionRangeThreshold = 1000f;
+    if (ShouldEvade(evasionRangeThreshold)) {
+      accelerationInput = EvadeInterceptor(GetClosestInterceptor());
+    } else if (HasAssignedTarget()) {
       // Update waypoint and power setting
       UpdateWaypointAndPower();
 
       // Calculate and apply acceleration
-      Vector3 accelerationInput = CalculateAccelerationToWaypoint();
-      ApplyAcceleration(accelerationInput);
+      accelerationInput = CalculateAccelerationToWaypoint();
     }
+
+    // For RotaryWingThreat, we don't need to compensate for gravity or consider drag
+    GetComponent<Rigidbody>().AddForce(accelerationInput, ForceMode.Acceleration);
   }
 
   private void UpdateWaypointAndPower() {
@@ -44,26 +52,21 @@ public class RotaryWingThreat : Threat {
     Vector3 desiredVelocity = toWaypoint.normalized * desiredSpeed;
 
     // Calculate acceleration needed to reach desired velocity
-    Vector3 accelerationCommand = (desiredVelocity - currentVelocity) / (float)Time.fixedDeltaTime;
-    Vector3 forwardAccelerationCommand = Vector3.Project(accelerationCommand, transform.forward);
-    Vector3 normalAccelerationCommand = accelerationCommand - forwardAccelerationCommand;
+    Vector3 accelerationInput = (desiredVelocity - currentVelocity) / (float)Time.fixedDeltaTime;
+    Vector3 forwardAccelerationInput = Vector3.Project(accelerationInput, transform.forward);
+    Vector3 normalAccelerationInput = accelerationInput - forwardAccelerationInput;
 
     // Limit acceleration magnitude
     float maxForwardAcceleration = CalculateMaxForwardAcceleration();
-    forwardAccelerationCommand =
-        Vector3.ClampMagnitude(forwardAccelerationCommand, maxForwardAcceleration);
+    forwardAccelerationInput =
+        Vector3.ClampMagnitude(forwardAccelerationInput, maxForwardAcceleration);
     float maxNormalAcceleration = CalculateMaxNormalAcceleration();
-    normalAccelerationCommand =
-        Vector3.ClampMagnitude(normalAccelerationCommand, maxNormalAcceleration);
-    accelerationCommand = forwardAccelerationCommand + normalAccelerationCommand;
+    normalAccelerationInput =
+        Vector3.ClampMagnitude(normalAccelerationInput, maxNormalAcceleration);
+    accelerationInput = forwardAccelerationInput + normalAccelerationInput;
 
-    _accelerationCommand = accelerationCommand;  // Store for debugging
-    return accelerationCommand;
-  }
-
-  private void ApplyAcceleration(Vector3 acceleration) {
-    // For RotaryWingThreat, we don't need to compensate for gravity or consider drag
-    GetComponent<Rigidbody>().AddForce(acceleration, ForceMode.Acceleration);
+    _accelerationInput = accelerationInput;
+    return accelerationInput;
   }
 
   // Optional: Add this method to visualize debug information
@@ -73,7 +76,7 @@ public class RotaryWingThreat : Threat {
       Gizmos.DrawLine(transform.position, _currentWaypoint);
 
       Gizmos.color = Color.green;
-      Gizmos.DrawRay(transform.position, _accelerationCommand);
+      Gizmos.DrawRay(transform.position, _accelerationInput);
     }
   }
 }

--- a/Assets/Scripts/Threats/Threat.cs
+++ b/Assets/Scripts/Threats/Threat.cs
@@ -98,14 +98,20 @@ public abstract class Threat : Agent {
     return closestInterceptor;
   }
 
-  protected bool ShouldEvade(float rangeThreshold) {
+  protected bool ShouldEvade() {
+    if (!_dynamicAgentConfig.dynamic_config.flight_config.evasionEnabled) {
+      return false;
+    }
+
     Agent closestInterceptor = GetClosestInterceptor();
     if (closestInterceptor == null) {
       return false;
     }
 
+    float evasionRangeThreshold =
+        _dynamicAgentConfig.dynamic_config.flight_config.evasionRangeThreshold;
     SensorOutput sensorOutput = GetComponent<Sensor>().Sense(closestInterceptor);
-    return sensorOutput.position.range <= rangeThreshold && sensorOutput.velocity.range < 0;
+    return sensorOutput.position.range <= evasionRangeThreshold && sensorOutput.velocity.range < 0;
   }
 
   protected Vector3 EvadeInterceptor(Agent interceptor) {

--- a/Assets/Scripts/Threats/Threat.cs
+++ b/Assets/Scripts/Threats/Threat.cs
@@ -46,4 +46,86 @@ public abstract class Threat : Agent {
   protected override void FixedUpdate() {
     base.FixedUpdate();
   }
+
+  protected Vector3 CalculateForwardAcceleration() {
+    // Get the target speed for the current power setting
+    float targetSpeed = PowerTableLookup(_currentPowerSetting);
+
+    // Calculate the current speed
+    float currentSpeed = GetVelocity().magnitude;
+
+    // Speed error
+    float speedError = targetSpeed - currentSpeed;
+
+    // Proportional gain for speed control
+    float speedControlGain = 10.0f;  // Adjust this gain as necessary
+
+    // Desired acceleration to adjust speed
+    float desiredAccelerationMagnitude = speedControlGain * speedError;
+
+    // Limit the desired acceleration
+    float maxForwardAcceleration = CalculateMaxForwardAcceleration();
+    desiredAccelerationMagnitude =
+        Mathf.Clamp(desiredAccelerationMagnitude, -maxForwardAcceleration, maxForwardAcceleration);
+
+    // Acceleration direction (along current velocity direction)
+    Vector3 accelerationDirection = GetVelocity().normalized;
+
+    // Handle zero velocity case
+    if (accelerationDirection.magnitude < 0.1f) {
+      accelerationDirection = transform.forward;  // Default direction
+    }
+
+    // Calculate acceleration vector
+    Vector3 speedAdjustmentAcceleration = accelerationDirection * desiredAccelerationMagnitude;
+    return speedAdjustmentAcceleration;
+  }
+
+  protected Agent GetClosestInterceptor() {
+    if (_interceptors.Count == 0) {
+      return null;
+    }
+
+    Agent closestInterceptor = null;
+    float minDistance = float.MaxValue;
+    foreach (var interceptor in _interceptors) {
+      SensorOutput sensorOutput = GetComponent<Sensor>().Sense(interceptor);
+      if (sensorOutput.position.range < minDistance) {
+        closestInterceptor = interceptor;
+        minDistance = sensorOutput.position.range;
+      }
+    }
+    return closestInterceptor;
+  }
+
+  protected bool ShouldEvade(float rangeThreshold) {
+    Agent closestInterceptor = GetClosestInterceptor();
+    if (closestInterceptor == null) {
+      return false;
+    }
+
+    SensorOutput sensorOutput = GetComponent<Sensor>().Sense(closestInterceptor);
+    return sensorOutput.position.range <= rangeThreshold && sensorOutput.velocity.range < 0;
+  }
+
+  protected Vector3 EvadeInterceptor(Agent interceptor) {
+    // Set power setting to maximum
+    _currentPowerSetting = PowerSetting.MAX;
+
+    // Evade the interceptor by changing the velocity to be normal to the interceptor's velocity
+    Vector3 normalVelocity = Vector3.ProjectOnPlane(GetVelocity(), interceptor.GetVelocity());
+    Vector3 normalAccelerationDirection =
+        Vector3.ProjectOnPlane(normalVelocity, GetVelocity()).normalized;
+
+    // Turn away from the interceptor
+    Vector3 relativePosition = interceptor.GetPosition() - GetPosition();
+    if (Vector3.Dot(relativePosition, normalAccelerationDirection) > 0) {
+      normalAccelerationDirection *= -1;
+    }
+    Vector3 normalAcceleration = normalAccelerationDirection * CalculateMaxNormalAcceleration();
+
+    // Adjust forward speed
+    Vector3 forwardAcceleration = CalculateForwardAcceleration();
+    return normalAcceleration + forwardAcceleration;
+  }
 }

--- a/Assets/StreamingAssets/Configs/1_salvo_1_hydra_7_drones.json
+++ b/Assets/StreamingAssets/Configs/1_salvo_1_hydra_7_drones.json
@@ -67,6 +67,10 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "evasionEnabled": true,
+            "evasionRangeThreshold": 1000
           }
         },
         "submunitions_config": {

--- a/Assets/StreamingAssets/Configs/2_salvo_2_hydra_7_quad_3_ucav.json
+++ b/Assets/StreamingAssets/Configs/2_salvo_2_hydra_7_quad_3_ucav.json
@@ -19,6 +19,9 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "evasionEnabled": false
           }
         },
         "submunitions_config": {
@@ -40,6 +43,10 @@
               "sensor_config": {
                 "type": "IDEAL",
                 "frequency": 100
+              },
+              "flight_config": {
+                "evasionEnabled": true,
+                "evasionRangeThreshold": 1000
               }
             }
           }
@@ -64,6 +71,9 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "evasionEnabled": false
           }
         },
         "submunitions_config": {
@@ -85,6 +95,10 @@
               "sensor_config": {
                 "type": "IDEAL",
                 "frequency": 100
+              },
+              "flight_config": {
+                "evasionEnabled": true,
+                "evasionRangeThreshold": 1000
               }
             }
           }
@@ -112,6 +126,10 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "evasionEnabled": true,
+            "evasionRangeThreshold": 1000
           }
         },
         "submunitions_config": {
@@ -138,6 +156,10 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "evasionEnabled": true,
+            "evasionRangeThreshold": 1000
           }
         },
         "submunitions_config": {

--- a/Assets/StreamingAssets/Configs/3_salvo_10_hydra_200_drones.json
+++ b/Assets/StreamingAssets/Configs/3_salvo_10_hydra_200_drones.json
@@ -157,6 +157,10 @@
           "sensor_config": {
             "type": "IDEAL",
             "frequency": 100
+          },
+          "flight_config": {
+            "evasionEnabled": true,
+            "evasionRangeThreshold": 1000
           }
         },
         "submunitions_config": {

--- a/Assets/Tests/EditMode/ThreatTests.cs
+++ b/Assets/Tests/EditMode/ThreatTests.cs
@@ -190,12 +190,12 @@ public class ThreatTests : AgentTestBase {
   }
 
   [Test]
-  public void FixedWingThreat_CalculateAccelerationCommand_RespectsMaxForwardAcceleration() {
+  public void FixedWingThreat_CalculateAccelerationInput_RespectsMaxForwardAcceleration() {
     SetPrivateField(fixedWingThreat, "_currentWaypoint", Vector3.one * 1000f);
     SensorOutput sensorOutput =
         fixedWingThreat.GetComponent<Sensor>().SenseWaypoint(Vector3.one * 1000f);
     Vector3 acceleration =
-        InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationCommand", sensorOutput);
+        InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationInput", sensorOutput);
     float maxForwardAcceleration =
         InvokePrivateMethod<float>(fixedWingThreat, "CalculateMaxForwardAcceleration");
     Assert.LessOrEqual((Vector3.Project(acceleration, fixedWingThreat.transform.forward)).magnitude,
@@ -203,12 +203,12 @@ public class ThreatTests : AgentTestBase {
   }
 
   [Test]
-  public void FixedWingThreat_CalculateAccelerationCommand_RespectsMaxNormalAcceleration() {
+  public void FixedWingThreat_CalculateAccelerationInput_RespectsMaxNormalAcceleration() {
     SetPrivateField(fixedWingThreat, "_currentWaypoint", Vector3.one * 1000f);
     SensorOutput sensorOutput =
         fixedWingThreat.GetComponent<Sensor>().SenseWaypoint(Vector3.one * 1000f);
     Vector3 acceleration =
-        InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationCommand", sensorOutput);
+        InvokePrivateMethod<Vector3>(fixedWingThreat, "CalculateAccelerationInput", sensorOutput);
     float maxNormalAcceleration =
         InvokePrivateMethod<float>(fixedWingThreat, "CalculateMaxNormalAcceleration");
     Assert.LessOrEqual(acceleration.magnitude, maxNormalAcceleration);
@@ -273,7 +273,7 @@ public class ThreatTests : AgentTestBase {
     Assert.AreEqual(desiredSpeed, powerSetting);
 
     // Act
-    Vector3 accelerationCommand =
+    Vector3 accelerationInput =
         InvokePrivateMethod<Vector3>(rotaryWingThreat, "CalculateAccelerationToWaypoint");
 
     // Assert
@@ -296,9 +296,9 @@ public class ThreatTests : AgentTestBase {
     normalAcceleration = Vector3.ClampMagnitude(normalAcceleration, maxNormalAcceleration);
     expectedAcceleration = forwardAcceleration + normalAcceleration;
 
-    Assert.AreEqual(expectedAcceleration.magnitude, accelerationCommand.magnitude, 0.1f,
+    Assert.AreEqual(expectedAcceleration.magnitude, accelerationInput.magnitude, 0.1f,
                     "Acceleration magnitude should match expected");
-    Assert.AreEqual(expectedAcceleration.normalized, accelerationCommand.normalized,
+    Assert.AreEqual(expectedAcceleration.normalized, accelerationInput.normalized,
                     "Acceleration direction should be towards waypoint");
   }
 }


### PR DESCRIPTION
This PR adds a preliminary threat evasion maneuver from incoming interceptors.  Once an interceptor assigned to a target is within some `evasionRangeThreshold` of the target with a positive closing velocity, the threat will ignore its current target and try to evade the interceptor.

The evasion maneuver currently implemented makes the threat turn away from the interceptor while trying to maintain a velocity vector that is normal to the interceptor's velocity vector.  Future work is to improve this evasion maneuver.

A static shot of the threats evading the interceptors:
<img width="959" alt="evasion" src="https://github.com/user-attachments/assets/f1527180-6f5a-413f-b882-3ac304f8f7e9">
