### PR TITLE
Remove compensation for gravity

### DIFF
--- a/Assets/Scripts/Agent.cs
+++ b/Assets/Scripts/Agent.cs
@@ -249,14 +249,8 @@ public abstract class Agent : MonoBehaviour {
     }
   }
 
-  protected Vector3 CalculateAcceleration(Vector3 accelerationInput,
-                                          bool compensateForGravity = false) {
+  protected Vector3 CalculateAcceleration(Vector3 accelerationInput) {
     Vector3 gravity = Physics.gravity;
-    if (compensateForGravity) {
-      Vector3 gravityProjection = CalculateGravityProjectionOnPitchAndYaw();
-      accelerationInput -= gravityProjection;
-    }
-
     float airDrag = CalculateDrag();
     float liftInducedDrag = CalculateLiftInducedDrag(accelerationInput + gravity);
     float dragAcceleration = -(airDrag + liftInducedDrag);

--- a/Assets/Scripts/Interceptor.cs
+++ b/Assets/Scripts/Interceptor.cs
@@ -63,7 +63,7 @@ public class Interceptor : Agent {
     Vector3 accelerationInput = boostAcceleration * rollAxis;
 
     // Calculate the total acceleration
-    Vector3 acceleration = CalculateAcceleration(accelerationInput, compensateForGravity: false);
+    Vector3 acceleration = CalculateAcceleration(accelerationInput);
 
     // Apply the acceleration force
     GetComponent<Rigidbody>().AddForce(acceleration, ForceMode.Acceleration);
@@ -97,7 +97,7 @@ public class Interceptor : Agent {
     }
 
     // Calculate and set the total acceleration
-    Vector3 acceleration = CalculateAcceleration(accelerationInput, compensateForGravity: true);
+    Vector3 acceleration = CalculateAcceleration(accelerationInput);
     GetComponent<Rigidbody>().AddForce(acceleration, ForceMode.Acceleration);
   }
 

--- a/Assets/Scripts/Threats/FixedWingThreat.cs
+++ b/Assets/Scripts/Threats/FixedWingThreat.cs
@@ -52,7 +52,7 @@ public class FixedWingThreat : Threat {
     }
 
     // Calculate and set the total acceleration
-    Vector3 acceleration = CalculateAcceleration(accelerationInput, compensateForGravity: true);
+    Vector3 acceleration = CalculateAcceleration(accelerationInput);
     GetComponent<Rigidbody>().AddForce(acceleration, ForceMode.Acceleration);
   }
 


### PR DESCRIPTION
As title.  With `compensateForGravity`, micromissiles will never fall into the ocean.