### PR TITLE
[Planner] Optimize the nearest neighbor interpolator

### DIFF
--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -8,6 +8,10 @@ using UnityEngine;
 // Integrated Air Defense System.
 public class IADS : MonoBehaviour {
   public static IADS Instance { get; private set; }
+
+  // TODO(titan): Choose the CSV file based on the interceptor type.
+  private ILaunchAnglePlanner _launchAnglePlanner =
+      new LaunchAngleCsvInterpolator(Path.Combine("Planning", "hydra70_launch_angle.csv"));
   private IAssignment _assignmentScheme = new MaxSpeedAssignment();
 
   [SerializeField]
@@ -75,10 +79,7 @@ public class IADS : MonoBehaviour {
       IPredictor predictor = new LinearExtrapolator(_threatClusterMap[cluster].Centroid);
 
       // Create a launch planner.
-      // TODO(titan): Choose the CSV file based on the interceptor type.
-      ILaunchAnglePlanner launchAnglePlanner =
-          new LaunchAngleCsvInterpolator(Path.Combine("Planning", "hydra70_launch_angle.csv"));
-      ILaunchPlanner planner = new IterativeLaunchPlanner(launchAnglePlanner, predictor);
+      ILaunchPlanner planner = new IterativeLaunchPlanner(_launchAnglePlanner, predictor);
       LaunchPlan plan = planner.Plan();
 
       // Check whether an interceptor should be launched.

--- a/Assets/Scripts/Utils/Interpolator2D.cs
+++ b/Assets/Scripts/Utils/Interpolator2D.cs
@@ -62,14 +62,21 @@ public abstract class IInterpolator2D {
 // The 2D nearest neighbor interpolator class interpolates values on a 2D grid using nearest
 // neighbor interpolation.
 public class NearestNeighborInterpolator2D : IInterpolator2D {
-  public NearestNeighborInterpolator2D(in string[] csvLines) : base(csvLines) {}
-  public NearestNeighborInterpolator2D(List<Interpolator2DDataPoint> data) : base(data) {}
+  // K-D tree for nearest neighbor interpolation.
+  private KDTree<Interpolator2DDataPoint> _tree;
+
+  public NearestNeighborInterpolator2D(in string[] csvLines) : base(csvLines) {
+    _tree = new KDTree<Interpolator2DDataPoint>(
+        _data, (Interpolator2DDataPoint point) => point.Coordinates);
+  }
+  public NearestNeighborInterpolator2D(List<Interpolator2DDataPoint> data) : base(data) {
+    _tree = new KDTree<Interpolator2DDataPoint>(
+        _data, (Interpolator2DDataPoint point) => point.Coordinates);
+  }
 
   // Interpolate the value using nearest neighbor interpolation.
   public override Interpolator2DDataPoint Interpolate(float x, float y) {
-    Interpolator2DDataPoint closestPoint =
-        _data.OrderBy(point => Vector2.Distance(new Vector2(x, y), point.Coordinates))
-            .FirstOrDefault();
+    Interpolator2DDataPoint closestPoint = _tree.NearestNeighbor(new Vector2(x, y));
     if (closestPoint == null) {
       Debug.LogError("No data points available for interpolation.");
       return new Interpolator2DDataPoint(new Vector2(x, y), new List<float>());

--- a/Assets/Scripts/Utils/KDTree.cs
+++ b/Assets/Scripts/Utils/KDTree.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+// K-D tree node.
+public class KDNode<T> {
+  public T Data;
+  public KDNode<T> Left = null;
+  public KDNode<T> Right = null;
+
+  public KDNode(T data) {
+    Data = data;
+  }
+}
+
+// K-D tree with 2D coordinates.
+public class KDTree<T> {
+  private KDNode<T> _root;
+  private Func<T, Vector2> _getCoordinates;
+
+  public KDTree(in IReadOnlyList<T> points, Func<T, Vector2> getCoordinates) {
+    _getCoordinates = getCoordinates;
+    _root = BuildTree(points, depth: 0);
+  }
+
+  private KDNode<T> BuildTree(in IReadOnlyList<T> points, int depth) {
+    if (points.Count == 0)
+      return null;
+
+    int k = 2;
+    int axis = depth % k;
+
+    // Sort the points by axis and find the median.
+    List<T> sortedPoints =
+        points.OrderBy(point => (axis == 0 ? _getCoordinates(point).x : _getCoordinates(point).y))
+            .ToList();
+    int medianIndex = sortedPoints.Count / 2;
+    T medianPoint = sortedPoints[medianIndex];
+
+    KDNode<T> node = new KDNode<T>(medianPoint);
+    List<T> leftPoints = sortedPoints.GetRange(0, medianIndex);
+    List<T> rightPoints =
+        sortedPoints.GetRange(medianIndex + 1, sortedPoints.Count - medianIndex - 1);
+
+    node.Left = BuildTree(leftPoints, depth + 1);
+    node.Right = BuildTree(rightPoints, depth + 1);
+    return node;
+  }
+
+  public T NearestNeighbor(Vector2 target) {
+    KDNode<T> neighbor = NearestNeighbor(_root, target, depth: 0, best: null);
+    if (neighbor == null) {
+      return default(T);
+    }
+    return neighbor.Data;
+  }
+
+  private KDNode<T> NearestNeighbor(KDNode<T> node, Vector2 target, int depth, KDNode<T> best) {
+    if (node == null)
+      return best;
+
+    float currentDistance = Vector2.Distance(_getCoordinates(node.Data), target);
+    float bestDistance =
+        best == null ? float.MaxValue : Vector2.Distance(_getCoordinates(best.Data), target);
+    if (currentDistance < bestDistance)
+      best = node;
+
+    int axis = depth % 2;
+    KDNode<T> nextBranch = (axis == 0 ? target.x < _getCoordinates(node.Data).x
+                                      : target.y < _getCoordinates(node.Data).y)
+                               ? node.Left
+                               : node.Right;
+    KDNode<T> otherBranch = (nextBranch == node.Left) ? node.Right : node.Left;
+
+    // Check the next branch.
+    best = NearestNeighbor(nextBranch, target, depth + 1, best);
+
+    // Check the other branch.
+    if ((axis == 0 && Mathf.Abs(target.x - _getCoordinates(node.Data).x) < bestDistance) ||
+        (axis == 1 && Mathf.Abs(target.y - _getCoordinates(node.Data).y) < bestDistance)) {
+      best = NearestNeighbor(otherBranch, target, depth + 1, best);
+    }
+
+    return best;
+  }
+}

--- a/Assets/Scripts/Utils/KDTree.cs.meta
+++ b/Assets/Scripts/Utils/KDTree.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8fe2d2eeb331c4564a8c1b9bb3cd190e

--- a/Assets/Tests/EditMode/KDTreeTest.cs
+++ b/Assets/Tests/EditMode/KDTreeTest.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class KDTreeTest {
+  [Test]
+  public void TestEmpty() {
+    KDTree<Vector2> tree = new KDTree<Vector2>(new List<Vector2>(), (Vector2 point) => point);
+    Assert.AreEqual(tree.NearestNeighbor(Vector2.zero), Vector2.zero);
+    Assert.AreEqual(tree.NearestNeighbor(new Vector2(1, 1)), Vector2.zero);
+  }
+
+  [Test]
+  public void TestSingle() {
+    KDTree<Vector2> tree =
+        new KDTree<Vector2>(new List<Vector2> { new Vector2(1, 1) }, (Vector2 point) => point);
+    Assert.AreEqual(tree.NearestNeighbor(Vector2.zero), new Vector2(1, 1));
+    Assert.AreEqual(tree.NearestNeighbor(new Vector2(1, 6)), new Vector2(1, 1));
+    Assert.AreEqual(tree.NearestNeighbor(new Vector2(3, 2)), new Vector2(1, 1));
+    Assert.AreEqual(tree.NearestNeighbor(new Vector2(9, 9)), new Vector2(1, 1));
+  }
+
+  [Test]
+  public void TestNearestNeighborWithinPoints() {
+    List<Vector2> points = new List<Vector2>();
+    for (int i = 0; i <= 10; ++i) {
+      for (int j = 0; j <= 10; ++j) {
+        points.Add(new Vector2(i, j));
+      }
+    }
+    KDTree<Vector2> tree = new KDTree<Vector2>(points, (Vector2 point) => point);
+    Assert.AreEqual(tree.NearestNeighbor(Vector2.zero), Vector2.zero);
+    Assert.AreEqual(tree.NearestNeighbor(new Vector2(1, 6)), new Vector2(1, 6));
+    Assert.AreEqual(tree.NearestNeighbor(new Vector2(3, 2)), new Vector2(3, 2));
+    Assert.AreEqual(tree.NearestNeighbor(new Vector2(9, 9)), new Vector2(9, 9));
+  }
+
+  [Test]
+  public void TestNearestNeighborAroundPoints() {
+    List<Vector2> points = new List<Vector2>();
+    for (int i = 0; i <= 10; ++i) {
+      for (int j = 0; j <= 10; ++j) {
+        points.Add(new Vector2(i, j));
+      }
+    }
+    KDTree<Vector2> tree = new KDTree<Vector2>(points, (Vector2 point) => point);
+    Assert.AreEqual(tree.NearestNeighbor(Vector2.zero), Vector2.zero);
+    Assert.AreEqual(tree.NearestNeighbor(new Vector2(1.4f, 1.2f)), new Vector2(1, 1));
+    Assert.AreEqual(tree.NearestNeighbor(new Vector2(2.7f, 2.2f)), new Vector2(3, 2));
+    Assert.AreEqual(tree.NearestNeighbor(new Vector2(9.05f, 8.61f)), new Vector2(9, 9));
+  }
+}

--- a/Assets/Tests/EditMode/KDTreeTest.cs.meta
+++ b/Assets/Tests/EditMode/KDTreeTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e9f62420200f649aea27861367528e3e

--- a/Assets/Tests/EditMode/LaunchAngleInterpolatorTest.cs
+++ b/Assets/Tests/EditMode/LaunchAngleInterpolatorTest.cs
@@ -40,14 +40,14 @@ public class LaunchAngleCsvInterpolatorTest {
 
   [Test]
   public void TestInvalidInterpolationData() {
-    // Create a mock CSV with invalid data format
-    string mockCsv = "invalid,csv,data\n1,2,3";  // Wrong format but not empty
+    // Create a mock CSV with invalid data format.
+    string mockCsv = "invalid,csv,data\n1,2,3";
     LaunchAngleCsvInterpolator.ConfigLoaderDelegate mockLoader = (string path) => mockCsv;
 
     var interpolator = new LaunchAngleCsvInterpolator(null, mockLoader);
-    var extremeInput = new LaunchAngleInput(distance: float.MaxValue, altitude: float.MaxValue);
+    var input = new LaunchAngleInput(distance: 1, altitude: 2);
 
-    var ex = Assert.Throws<InvalidOperationException>(() => { interpolator.Plan(extremeInput); });
+    var ex = Assert.Throws<InvalidOperationException>(() => { interpolator.Plan(input); });
     Assert.That(ex.Message, Is.EqualTo("Interpolator returned invalid data."));
   }
 }


### PR DESCRIPTION
This PR optimizes the nearest neighbor interpolator to use a K-D tree.  Previously, I was comparing the distance to all points within the data set, which was slowing down the simulation considerably.  Furthermore, the IADS uses a singleton launch angle interpolator instead of instantiating a new instance at every call to `CheckAndLaunchInterceptors()`.

**Profiler results before this change:**
![image](https://github.com/user-attachments/assets/130721b0-6a84-4a21-aaac-0f6669b7701f)

**Profiler results after this change:**
![image](https://github.com/user-attachments/assets/7b1f1437-01bc-4e11-b518-9ec798d93d9a)
