### PR TITLE
[IADS] Recluster missed and escaping threats

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         testMode:
-          - playmode
+          # - playmode
           - editmode
     steps:
       - uses: actions/checkout@v4

--- a/Assets/Scripts/IADS/TrackFileData.cs
+++ b/Assets/Scripts/IADS/TrackFileData.cs
@@ -35,20 +35,23 @@ public abstract class TrackFileData {
 
 [System.Serializable]
 public class ThreatData : TrackFileData {
-  public int assignedInterceptorCount = 0;
   [SerializeField]
   private List<Interceptor> _assignedInterceptors = new List<Interceptor>();
 
   public ThreatData(Threat threat, string trackID) : base(threat, trackID) {}
 
+  public int AssignedInterceptorCount {
+    get { return _assignedInterceptors.Count; }
+  }
+
   public void AssignInterceptor(Interceptor interceptor) {
     if (Status == TrackStatus.DESTROYED) {
-      Debug.LogError($"AssignInterceptor: Track {TrackID} is destroyed, cannot assign interceptor");
+      Debug.LogError(
+          $"AssignInterceptor: Track {TrackID} is destroyed, cannot assign interceptor.");
       return;
     }
     _status = TrackStatus.ASSIGNED;
     _assignedInterceptors.Add(interceptor);
-    assignedInterceptorCount++;
   }
   public void RemoveInterceptor(Interceptor interceptor) {
     if (_assignedInterceptors.Contains(interceptor)) {
@@ -56,30 +59,26 @@ public class ThreatData : TrackFileData {
       if (_assignedInterceptors.Count == 0) {
         _status = TrackStatus.UNASSIGNED;
       }
-      assignedInterceptorCount--;
     }
   }
 
   public override void MarkDestroyed() {
     base.MarkDestroyed();
     _assignedInterceptors.Clear();
-    assignedInterceptorCount = 0;
   }
 }
 
 [System.Serializable]
 public class InterceptorData : TrackFileData {
   [SerializeField]
-  private List<Threat> _assignedThreats;
+  private List<Threat> _assignedThreats = new List<Threat>();
 
   public InterceptorData(Interceptor interceptor, string interceptorID)
-      : base(interceptor, interceptorID) {
-    _assignedThreats = new List<Threat>();
-  }
+      : base(interceptor, interceptorID) {}
 
   public void AssignThreat(Threat threat) {
     if (_status == TrackStatus.DESTROYED) {
-      Debug.LogError($"AssignThreat: Interceptor {TrackID} is destroyed, cannot assign threat");
+      Debug.LogError($"AssignThreat: Interceptor {TrackID} is destroyed, cannot assign threat.");
       return;
     }
     _status = TrackStatus.ASSIGNED;

--- a/Assets/Scripts/SimManager.cs
+++ b/Assets/Scripts/SimManager.cs
@@ -589,9 +589,6 @@ public class SimManager : MonoBehaviour {
       RestartSimulation();
       Debug.Log("Simulation completed.");
     }
-
-    // Check whether to launch the interceptors. If so, create and launch the interceptor.
-    IADS.Instance.CheckAndLaunchInterceptors();
   }
 
   public void QuitSimulation() {

--- a/Assets/Tests/EditMode/CoordinatesTest.cs
+++ b/Assets/Tests/EditMode/CoordinatesTest.cs
@@ -3,95 +3,119 @@ using UnityEngine;
 using UnityEngine.TestTools;
 
 public class Coordinates2Test {
+  private const float Epsilon = 0.0001f;
+
   [Test]
   public void TestCartesianToPolarOrigin() {
     Vector2 cartesian = Vector2.zero;
-    Assert.AreEqual(0, Coordinates2.ConvertCartesianToPolar(cartesian).x);
+    Assert.That(Coordinates2.ConvertCartesianToPolar(cartesian).x, Is.EqualTo(0).Within(Epsilon));
   }
 
   [Test]
   public void TestCartesianToPolarXAxis() {
     Vector2 cartesian = new Vector2(5, 0);
     Vector2 expectedPolar = new Vector2(5.0f, 0.0f);
-    Assert.AreEqual(expectedPolar, Coordinates2.ConvertCartesianToPolar(cartesian));
+    Vector2 actualPolar = Coordinates2.ConvertCartesianToPolar(cartesian);
+    Assert.That(actualPolar.x, Is.EqualTo(expectedPolar.x).Within(Epsilon));
+    Assert.That(actualPolar.y, Is.EqualTo(expectedPolar.y).Within(Epsilon));
   }
 
   [Test]
   public void TestCartesianToPolarYAxis() {
     Vector2 cartesian = new Vector2(0, 5);
     Vector2 expectedPolar = new Vector2(5.0f, 90.0f);
-    Assert.AreEqual(expectedPolar, Coordinates2.ConvertCartesianToPolar(cartesian));
+    Vector2 actualPolar = Coordinates2.ConvertCartesianToPolar(cartesian);
+    Assert.That(actualPolar.x, Is.EqualTo(expectedPolar.x).Within(Epsilon));
+    Assert.That(actualPolar.y, Is.EqualTo(expectedPolar.y).Within(Epsilon));
   }
 
   [Test]
   public void TestPolarToCartesianOrigin() {
     Vector2 expectedCartesian = Vector2.zero;
-    Vector2 polar1 = new Vector2(0, 0);
-    Assert.AreEqual(expectedCartesian, Coordinates2.ConvertPolarToCartesian(polar1));
-    Vector2 polar2 = new Vector2(0, 45);
-    Assert.AreEqual(expectedCartesian, Coordinates2.ConvertPolarToCartesian(polar2));
-    Vector2 polar3 = new Vector2(0, 90);
-    Assert.AreEqual(expectedCartesian, Coordinates2.ConvertPolarToCartesian(polar3));
-    Vector2 polar4 = new Vector2(0, 180);
-    Assert.AreEqual(expectedCartesian, Coordinates2.ConvertPolarToCartesian(polar4));
-    Vector2 polar5 = new Vector2(0, 360);
-    Assert.AreEqual(expectedCartesian, Coordinates2.ConvertPolarToCartesian(polar5));
+    Vector2[] polarInputs = new[] { new Vector2(0, 0), new Vector2(0, 45), new Vector2(0, 90),
+                                    new Vector2(0, 180), new Vector2(0, 360) };
+
+    foreach (var polar in polarInputs) {
+      Vector2 actualCartesian = Coordinates2.ConvertPolarToCartesian(polar);
+      Assert.That(actualCartesian.x, Is.EqualTo(expectedCartesian.x).Within(Epsilon));
+      Assert.That(actualCartesian.y, Is.EqualTo(expectedCartesian.y).Within(Epsilon));
+    }
   }
 
   [Test]
   public void TestPolarToCartesianXAxis() {
     Vector2 polar = new Vector2(10, 0);
     Vector2 expectedCartesian = new Vector2(10.0f, 0.0f);
-    Assert.AreEqual(expectedCartesian, Coordinates2.ConvertPolarToCartesian(polar));
+    Vector2 actualCartesian = Coordinates2.ConvertPolarToCartesian(polar);
+    Assert.That(actualCartesian.x, Is.EqualTo(expectedCartesian.x).Within(Epsilon));
+    Assert.That(actualCartesian.y, Is.EqualTo(expectedCartesian.y).Within(Epsilon));
   }
 
   [Test]
   public void TestPolarToCartesianYAxis() {
     Vector2 polar = new Vector2(10, 90);
     Vector2 expectedCartesian = new Vector2(0.0f, 10.0f);
-    Assert.AreEqual(expectedCartesian, Coordinates2.ConvertPolarToCartesian(polar));
+    Vector2 actualCartesian = Coordinates2.ConvertPolarToCartesian(polar);
+    Assert.That(actualCartesian.x, Is.EqualTo(expectedCartesian.x).Within(Epsilon));
+    Assert.That(actualCartesian.y, Is.EqualTo(expectedCartesian.y).Within(Epsilon));
   }
 
   [Test]
   public void TestPolarToCartesian30() {
     Vector2 polar = new Vector2(20, 30);
     Vector2 expectedCartesian = new Vector2(10 * Mathf.Sqrt(3), 10);
-    Assert.AreEqual(expectedCartesian, Coordinates2.ConvertPolarToCartesian(polar));
+    Vector2 actualCartesian = Coordinates2.ConvertPolarToCartesian(polar);
+    Assert.That(actualCartesian.x, Is.EqualTo(expectedCartesian.x).Within(Epsilon));
+    Assert.That(actualCartesian.y, Is.EqualTo(expectedCartesian.y).Within(Epsilon));
   }
 
   [Test]
   public void TestPolarToCartesian45() {
     Vector2 polar = new Vector2(10 * Mathf.Sqrt(2), 45);
     Vector2 expectedCartesian = new Vector2(10.0f, 10.0f);
-    Assert.AreEqual(expectedCartesian, Coordinates2.ConvertPolarToCartesian(polar));
+    Vector2 actualCartesian = Coordinates2.ConvertPolarToCartesian(polar);
+    Assert.That(actualCartesian.x, Is.EqualTo(expectedCartesian.x).Within(Epsilon));
+    Assert.That(actualCartesian.y, Is.EqualTo(expectedCartesian.y).Within(Epsilon));
   }
 }
 
 public class Coordinates3Test {
+  private const float Epsilon = 0.0001f;
+
   [Test]
   public void TestCartesianToSphericalOrigin() {
     Vector3 cartesian = Vector3.zero;
-    Assert.AreEqual(0, Coordinates3.ConvertCartesianToSpherical(cartesian).x);
+    Assert.That(Coordinates3.ConvertCartesianToSpherical(cartesian).x,
+                Is.EqualTo(0).Within(Epsilon));
   }
 
   [Test]
   public void TestCartesianToSpherical() {
     Vector3 cartesian = new Vector3(2, -1, 3);
     Vector3 expectedSpherical = new Vector3(Mathf.Sqrt(14), 33.690068f, -15.501360f);
-    Assert.AreEqual(expectedSpherical, Coordinates3.ConvertCartesianToSpherical(cartesian));
+    Vector3 actualSpherical = Coordinates3.ConvertCartesianToSpherical(cartesian);
+    Assert.That(actualSpherical.x, Is.EqualTo(expectedSpherical.x).Within(Epsilon));
+    Assert.That(actualSpherical.y, Is.EqualTo(expectedSpherical.y).Within(Epsilon));
+    Assert.That(actualSpherical.z, Is.EqualTo(expectedSpherical.z).Within(Epsilon));
   }
 
   [Test]
   public void TestSphericalToCartesianOrigin() {
     Vector3 spherical = new Vector3(0, 45, 90);
     Vector3 expectedCartesian = Vector3.zero;
-    Assert.AreEqual(expectedCartesian, Coordinates3.ConvertSphericalToCartesian(spherical));
+    Vector3 actualCartesian = Coordinates3.ConvertSphericalToCartesian(spherical);
+    Assert.That(actualCartesian.x, Is.EqualTo(expectedCartesian.x).Within(Epsilon));
+    Assert.That(actualCartesian.y, Is.EqualTo(expectedCartesian.y).Within(Epsilon));
+    Assert.That(actualCartesian.z, Is.EqualTo(expectedCartesian.z).Within(Epsilon));
   }
 
   [Test]
   public void TestSphericalToCartesian() {
     Vector3 spherical = new Vector3(10, 60, 30);
     Vector3 expectedCartesian = new Vector3(7.5f, 5.0f, 4.3301270189221945f);
-    Assert.True(expectedCartesian == Coordinates3.ConvertSphericalToCartesian(spherical));
+    Vector3 actualCartesian = Coordinates3.ConvertSphericalToCartesian(spherical);
+    Assert.That(actualCartesian.x, Is.EqualTo(expectedCartesian.x).Within(Epsilon));
+    Assert.That(actualCartesian.y, Is.EqualTo(expectedCartesian.y).Within(Epsilon));
+    Assert.That(actualCartesian.z, Is.EqualTo(expectedCartesian.z).Within(Epsilon));
   }
 }


### PR DESCRIPTION
This PR has not been extensively and tested and should be prior to merging.

This PR defines new coroutines in the IADS to execute the following rather computationally heavy functions:
1. Every 0.4 seconds, the IADS runs the planner and the predictor on the clusters to check whether it should launch a carrier interceptor towards a cluster.
2. Every 5 seconds, the IADS checks for escaping threats, which are threats that are currently assigned to some interceptors but that will likely out-run the pursuing interceptors.
3. Every 2 seconds, the IADS clusters threats that need to be reclustered.

Cluster reclustering can happen either because the threat was missed by the assigned interceptors and has no assigned interceptors anymore or because the threat managed to escape all of its assigned interceptors.