### PR TITLE
[Assignment] Consider turning distance and fix air density constant in maximum speed assignment scheme

### DIFF
--- a/Assets/Scripts/Agent.cs
+++ b/Assets/Scripts/Agent.cs
@@ -414,11 +414,11 @@ public abstract class Agent : MonoBehaviour {
     return accelerationInput + gravity + dragAccelerationAlongRoll;
   }
 
-  protected float CalculateMaxForwardAcceleration() {
+  public float CalculateMaxForwardAcceleration() {
     return staticAgentConfig.accelerationConfig.maxForwardAcceleration;
   }
 
-  protected float CalculateMaxNormalAcceleration() {
+  public float CalculateMaxNormalAcceleration() {
     float maxReferenceNormalAcceleration =
         (float)(staticAgentConfig.accelerationConfig.maxReferenceNormalAcceleration *
                 Constants.kGravity);

--- a/Assets/Scripts/Assignment/MaxSpeedAssignment.cs
+++ b/Assets/Scripts/Assignment/MaxSpeedAssignment.cs
@@ -35,10 +35,11 @@ public class MaxSpeedAssignment : IAssignment {
     // Find all pairwise assignment costs.
     foreach (var interceptor in assignableInterceptors) {
       // The speed decays exponentially with the travelled distance and with the bearing change.
-      float distanceTimeConstant = 2 * interceptor.staticAgentConfig.bodyConfig.mass /
-                                   ((float)interceptor.GetDynamicPressure() *
-                                    interceptor.staticAgentConfig.liftDragConfig.dragCoefficient *
-                                    interceptor.staticAgentConfig.bodyConfig.crossSectionalArea);
+      float distanceTimeConstant =
+          2 * interceptor.staticAgentConfig.bodyConfig.mass /
+          ((float)Constants.CalculateAirDensityAtAltitude(interceptor.GetPosition().y) *
+           interceptor.staticAgentConfig.liftDragConfig.dragCoefficient *
+           interceptor.staticAgentConfig.bodyConfig.crossSectionalArea);
       float angleTimeConstant = interceptor.staticAgentConfig.liftDragConfig.liftDragRatio;
       // During the turn, the minimum radius dictates the minimum distance needed to make the turn.
       float minTurningRadius = (float)(interceptor.GetVelocity().sqrMagnitude /

--- a/Assets/Scripts/Assignment/MaxSpeedAssignment.cs
+++ b/Assets/Scripts/Assignment/MaxSpeedAssignment.cs
@@ -34,12 +34,15 @@ public class MaxSpeedAssignment : IAssignment {
 
     // Find all pairwise assignment costs.
     foreach (var interceptor in assignableInterceptors) {
-      // The speed decays exponentially with travelled distance and with the bearing change.
+      // The speed decays exponentially with the travelled distance and with the bearing change.
       float distanceTimeConstant = 2 * interceptor.staticAgentConfig.bodyConfig.mass /
                                    ((float)interceptor.GetDynamicPressure() *
                                     interceptor.staticAgentConfig.liftDragConfig.dragCoefficient *
                                     interceptor.staticAgentConfig.bodyConfig.crossSectionalArea);
       float angleTimeConstant = interceptor.staticAgentConfig.liftDragConfig.liftDragRatio;
+      // During the turn, the minimum radius dictates the minimum distance needed to make the turn.
+      float minTurningRadius = (float)(interceptor.GetVelocity().sqrMagnitude /
+                                       interceptor.CalculateMaxNormalAcceleration());
       foreach (var threat in activeThreats) {
         Vector3 directionToThreat = threat.GetPosition() - interceptor.GetPosition();
         float distanceToThreat = directionToThreat.magnitude;
@@ -48,7 +51,8 @@ public class MaxSpeedAssignment : IAssignment {
 
         // The speed loss factor is the product of the speed lost through distance and of the speed
         // lost through turning, and we define the cost to be the (1 - speed loss factor).
-        float cost = 1 - Mathf.Exp(-(distanceToThreat / distanceTimeConstant +
+        float cost = 1 - Mathf.Exp(-((distanceToThreat + angleToThreat * minTurningRadius) /
+                                         distanceTimeConstant +
                                      angleToThreat / angleTimeConstant));
         assignmentCosts.Enqueue(new IAssignment.AssignmentItem(interceptor, threat), cost);
       }


### PR DESCRIPTION
This PR improves the maximum speed assignment scheme:
1. The maximum speed assignment scheme now considers the turning distance in addition to the turn angle.  The turning distance is a function of the minimum turning radius (dictated by the agent's current speed and its maximum normal acceleration to follow a circular path).
2. The PR fixes a major bug in the maximum speed assignment scheme.  The distance time constant is given by $\frac{2m}{\rho C_D A}$, where $\rho$ is the air density.  However, instead of using the air density, the assignment scheme was using the dynamic pressure, which is equal to $\frac{1}{2} \rho \|\vec{v}\|^2$.  Thus, the time constant was too small, and any reasonable distance to any threat would drastically increase the cost of the assignment.