### PR TITLE
[Build] Add Protobuf flag to allow MSVC + Bazel

### DIFF
--- a/plugins/.bazelrc
+++ b/plugins/.bazelrc
@@ -10,3 +10,7 @@ build:windows --host_cxxopt=/std:c++20
 build:linux --objccopt=-std=c++20
 build:macos --objccopt=-std=c++20
 build:windows --objccopt=/std:c++20
+
+# This flag is required by Protobuf because it is dropping support for MSVC + Bazel.
+# See https://github.com/protocolbuffers/protobuf/issues/20085 for more details and track https://github.com/protocolbuffers/protobuf/pull/22632 for a possible revert.
+build:windows --define=protobuf_allow_msvc=true

--- a/plugins/.bazelrc
+++ b/plugins/.bazelrc
@@ -11,6 +11,9 @@ build:linux --objccopt=-std=c++20
 build:macos --objccopt=-std=c++20
 build:windows --objccopt=/std:c++20
 
-# This flag is required by Protobuf because it is dropping support for MSVC + Bazel.
-# See https://github.com/protocolbuffers/protobuf/issues/20085 for more details and track https://github.com/protocolbuffers/protobuf/pull/22632 for a possible revert.
+# This flag is required by Protobuf because it is dropping support for MSVC +
+# Bazel.
+# See https://github.com/protocolbuffers/protobuf/issues/20085 for more details
+# and track https://github.com/protocolbuffers/protobuf/pull/22632 for a
+# possible revert.
 build:windows --define=protobuf_allow_msvc=true

--- a/plugins/MODULE.bazel
+++ b/plugins/MODULE.bazel
@@ -21,7 +21,6 @@ bazel_dep(
 bazel_dep(
     name = "googletest",
     version = "1.17.0",
-    repo_name = "com_google_googletest",
 )
 bazel_dep(
     name = "platforms",

--- a/plugins/assignment/BUILD.bazel
+++ b/plugins/assignment/BUILD.bazel
@@ -28,8 +28,8 @@ cc_test(
     deps = [
         ":assignment",
         ":cover_assignment",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
     ],
 )
 
@@ -50,8 +50,8 @@ cc_test(
     deps = [
         ":assignment",
         ":even_assignment",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
     ],
 )
 
@@ -73,8 +73,8 @@ cc_test(
     deps = [
         ":assignment",
         ":weighted_even_assignment",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
     ],
 )
 

--- a/plugins/example/BUILD.bazel
+++ b/plugins/example/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/plugins/experimental/BUILD.bazel
+++ b/plugins/experimental/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_binary(


### PR DESCRIPTION
As mentioned in #49, this additional flag allows Protobuf to be successfully compiled on Windows.

See https://github.com/PisterLab/micromissiles-unity/actions/runs/16305928163 for a successful Windows build of the plugins.