### PR TITLE
[Actions] Deploy docs on push to master only

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
       - release
   schedule:
     - cron: '0 2 * * *'  # Run at 2 AM UTC every day.
-  workflow_dispatch:
+  workflow_dispatch:  # Allow manual triggering.
 
 jobs:
   buildPlugins:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,10 +16,6 @@ permissions:
 
 jobs:
   build:
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -39,6 +35,11 @@ jobs:
   deploy:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
     steps:
       - name: Deploy documentation
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,7 +15,7 @@ permissions:
   id-token: write
 
 jobs:
-  build-deploy:
+  build:
     permissions:
       contents: write
       pages: write
@@ -36,8 +36,11 @@ jobs:
       - name: Build documentation
         run: npm run docs:build
 
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
       - name: Deploy documentation
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,4 @@
-name: Deploy Documentation
+name: Documentation
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:  # Allows manual triggering.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'  # Use Node.js 18
+          node-version: '18'
 
       - name: Install dependencies
         run: npm ci
@@ -37,6 +37,7 @@ jobs:
         run: npm run docs:build
 
       - name: Deploy documentation
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    name: Build documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -33,6 +34,7 @@ jobs:
         run: npm run docs:build
 
   deploy:
+    name: Deploy documentation
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     permissions:
@@ -41,7 +43,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy documentation
+      - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:
+  workflow_dispatch:  # Allow manual triggering.
 
 permissions:
   contents: write

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:
+  workflow_dispatch:  # Allow manual triggering.
 
 jobs:
   clang-format:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,11 @@
 name: Test
 
 on:
-    schedule:
-      - cron: '0 2 * * *'  # Runs at 2 AM UTC every day.
     pull_request:
       branches:
         - master
+    schedule:
+      - cron: '0 2 * * *'  # Runs at 2 AM UTC every day.
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
         - master
     schedule:
       - cron: '0 2 * * *'  # Runs at 2 AM UTC every day.
-    workflow_dispatch:
+    workflow_dispatch:  # Allow manual triggering.
 
 jobs:
   testPlugins:


### PR DESCRIPTION
This PR fixes the loophole where any bad actor could create a PR with incorrect documentation changes, and it'll be public immediately.