### PR TITLE
[Docs] Fix deploying documentation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,15 +9,12 @@ on:
       - master
   workflow_dispatch:  # Allow manual triggering.
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
-
 jobs:
-  build:
-    name: Build documentation
+  build-deploy:
+    name: Build and deploy documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,21 +30,9 @@ jobs:
       - name: Build documentation
         run: npm run docs:build
 
-  deploy:
-    name: Deploy documentation
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/.vitepress/dist
-          allow_empty_commit: true
-          keep_files: true
-          force_orphan: false


### PR DESCRIPTION
My previous PR #53 broke the documentation deployment job because I separated the build and deploy jobs.  This PR fixes that and also cleans up the action.  See https://github.com/peaceiris/actions-gh-pages for more details on the action options.
* The GitHub token already has the following permissions, so we don't need to specify more:
  ```
  GITHUB_TOKEN Permissions
  Contents: write
  Metadata: read
  Pages: write
  ```
* `allow_empty_commit` is not needed to prevent spamming the `gh-pages` branch.
* `keep_files` should be removed because older files will not be removed.  For example, `Cpp_Plugins_Guide.html` still exists after renaming the page to `Plugins_Guide.html`.
* `force_orphan` is false by default.