### PR TITLE
[Actions] Trigger build and test actions on all pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,16 +1,13 @@
 name: Build
 
 on:
+  pull_request:  # Run on all branches.
   push:
     branches:
       - master
       - release
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
-    branches:
-      - master
-      - release
   schedule:
     - cron: '0 2 * * *'  # Run at 2 AM UTC every day.
   workflow_dispatch:  # Allow manual triggering.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,8 +1,10 @@
 name: Documentation
 
 on:
-  pull_request:
-    branches: [master]
+  pull_request:  # Run on all branches.
+  push:
+    branches:
+      - master
   workflow_run:
     workflows: [Test]
     types: [completed]
@@ -41,7 +43,11 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master'
+        if: |
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_branch == 'master' &&
+          github.event.workflow_run.conclusion == 'success'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/.vitepress/dist

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,12 +1,8 @@
 name: Linter
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  pull_request:  # Run on all branches.
+  push:  # Run on all branches and tags.
   workflow_dispatch:  # Allow manual triggering.
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,8 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     if: |
-      github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_branch, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,14 +1,15 @@
 name: Test
 
 on:
+  pull_request:  # Run on all branches.
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
+      - release
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   schedule:
-    - cron: '0 2 * * *'  # Runs at 2 AM UTC every day.
+    - cron: '0 2 * * *'  # Run at 2 AM UTC every day.
   workflow_dispatch:  # Allow manual triggering.
 
 jobs:


### PR DESCRIPTION
This PR refines when certain GitHub actions are triggered:
- In particular, the `Build` action is triggered on every pull request, even those not to `master`.  This will facilitate the usage of stacked PRs.  The same reasoning applies to the `Test` action.
- Documentation is based on the `master` branch, so it should also run when someone pushes directly to the `master` branch.
- The linter is fast, so it should run on all pull requests and pushes.