### PR TITLE
[Bugfix] Ensure idle interceptors experience gravity & avoid null ref excepts in target model update

### DIFF
--- a/Assets/Scripts/Interceptor.cs
+++ b/Assets/Scripts/Interceptor.cs
@@ -79,12 +79,12 @@ public class Interceptor : AerialAgent {
     float maxNormalAcceleration = CalculateMaxNormalAcceleration();
 
     if (!HasAssignedTarget()) {
-      // Counter gravity if possible.
-      accelerationInput =
-          (float)Constants.kGravity / Vector3.Dot(transform.up, Vector3.up) * transform.up;
-      accelerationInput = Vector3.ClampMagnitude(accelerationInput, maxNormalAcceleration);
-      _accelerationInput = accelerationInput;
-      return accelerationInput;
+      // No assigned target: do not generate control input.
+      // Gravity and drag are applied centrally in AerialAgent.CalculateAcceleration,
+      // so returning zero here ensures idle missiles/carriers still experience gravity
+      // and do not artificially hover.
+      _accelerationInput = Vector3.zero;
+      return _accelerationInput;
     }
 
     UpdateTargetModel(deltaTime);
@@ -112,8 +112,19 @@ public class Interceptor : AerialAgent {
   }
 
   private void UpdateTargetModel(double deltaTime) {
+    // Skip if target/model/sensor is unavailable. This prevents null dereferences
+    // during phases before assignment or when configs are incomplete.
+    if (_targetModel == null || _target == null) {
+      return;
+    }
+
+    var sensorConfig = dynamicAgentConfig?.dynamic_config?.sensor_config;
+    if (sensorConfig == null || sensorConfig.frequency <= 0f) {
+      return;
+    }
+
     _elapsedTime += deltaTime;
-    float sensorUpdatePeriod = 1f / dynamicAgentConfig.dynamic_config.sensor_config.frequency;
+    float sensorUpdatePeriod = 1f / sensorConfig.frequency;
     if (_elapsedTime >= sensorUpdatePeriod) {
       // TODO: Implement guidance filter to estimate state from the sensor output.
       // For now, we'll use the threat's actual state.


### PR DESCRIPTION
Idle controller input: When an interceptor has no assigned target, we now return zero control input. Gravity and drag are still applied centrally in `AerialAgent.CalculateAcceleration`, so missiles/carriers fall naturally instead of hovering.

UpdateTargetModel now returns early when target/model/sensor config is missing to prevent null reference exceptions during phases before assignment or with incomplete configs.


After fix:
<img width="1735" height="800" alt="image" src="https://github.com/user-attachments/assets/d2129c59-9d51-4a08-b67c-c822941fffe6" />

Addresses #69  (lol)
