### PR TITLE
[Actions] Add windows-latest platform target to Bazel `Test plugins` job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,14 @@ on:
 
 jobs:
   test-plugins:
-    name: Test plugins
-    runs-on: ubuntu-latest
+    name: Test plugins on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/plugins/protobuf/protobuf_test.cc
+++ b/plugins/protobuf/protobuf_test.cc
@@ -4,7 +4,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <filesystem>
+#include <string>
 #include <vector>
 
 #include "Configs/attack_behavior_config.pb.h"
@@ -16,9 +16,8 @@ namespace protobuf {
 namespace {
 
 TEST(ProtobufTest, LoadProtobufTextAttackBehaviorConfigFileTest) {
-  const auto kAttackBehaviorConfigFile =
-      std::filesystem::path("..") / "micromissiles-configs-data+" / "Attacks" /
-      "default_direct_attack.pbtxt";
+  const std::string kAttackBehaviorConfigFile =
+      "../micromissiles-configs-data+/Attacks/default_direct_attack.pbtxt";
   configs::AttackBehaviorConfig attack_behavior_config;
   const auto status = LoadProtobufTextFile<configs::AttackBehaviorConfig>(
       kAttackBehaviorConfigFile, &attack_behavior_config);
@@ -28,9 +27,8 @@ TEST(ProtobufTest, LoadProtobufTextAttackBehaviorConfigFileTest) {
 }
 
 TEST(ProtobufTest, LoadProtobufTextStaticConfigFileTest) {
-  const auto kStaticConfigFile = std::filesystem::path("..") /
-                                 "micromissiles-configs-data+" / "Models" /
-                                 "micromissile.pbtxt";
+  const std::string kStaticConfigFile =
+      "../micromissiles-configs-data+/Models/micromissile.pbtxt";
   configs::StaticConfig static_config;
   const auto status = LoadProtobufTextFile<configs::StaticConfig>(
       kStaticConfigFile, &static_config);
@@ -43,9 +41,8 @@ TEST(ProtobufTest, LoadProtobufTextStaticConfigFileTest) {
 }
 
 TEST(ProtobufTest, LoadProtobufTextSimulationConfigFileTest) {
-  const auto kSimulationConfigFile = std::filesystem::path("..") /
-                                     "micromissiles-configs-data+" /
-                                     "Simulations" / "7_quadcopters.pbtxt";
+  const std::string kSimulationConfigFile =
+      "../micromissiles-configs-data+/Simulations/7_quadcopters.pbtxt";
   configs::SimulationConfig simulation_config;
   const auto status = LoadProtobufTextFile<configs::SimulationConfig>(
       kSimulationConfigFile, &simulation_config);
@@ -55,9 +52,8 @@ TEST(ProtobufTest, LoadProtobufTextSimulationConfigFileTest) {
 }
 
 TEST(ProtobufTest, LoadProtobufTextInvalidFileTest) {
-  const auto kSimulationConfigFile = std::filesystem::path("..") /
-                                     "micromissiles-configs-data+" /
-                                     "Simulations" / "invalid.pbtxt";
+  const std::string kSimulationConfigFile =
+      "../micromissiles-configs-data+/Simulations/invalid.pbtxt";
   configs::SimulationConfig simulation_config;
   const auto status = LoadProtobufTextFile<configs::SimulationConfig>(
       kSimulationConfigFile, &simulation_config);
@@ -65,9 +61,8 @@ TEST(ProtobufTest, LoadProtobufTextInvalidFileTest) {
 }
 
 TEST(ProtobufTest, SerializeToBufferTest) {
-  const auto kStaticConfigFile = std::filesystem::path("..") /
-                                 "micromissiles-configs-data+" / "Models" /
-                                 "micromissile.pbtxt";
+  const std::string kStaticConfigFile =
+      "../micromissiles-configs-data+/Models/micromissile.pbtxt";
   configs::StaticConfig static_config;
   const auto load_status = LoadProtobufTextFile<configs::StaticConfig>(
       kStaticConfigFile, &static_config);
@@ -81,9 +76,8 @@ TEST(ProtobufTest, SerializeToBufferTest) {
 }
 
 TEST(ProtobufTest, SerializeToBufferInsufficientSizeTest) {
-  const auto kStaticConfigFile = std::filesystem::path("..") /
-                                 "micromissiles-configs-data+" / "Models" /
-                                 "micromissile.pbtxt";
+  const std::string kStaticConfigFile =
+      "../micromissiles-configs-data+/Models/micromissile.pbtxt";
   configs::StaticConfig static_config;
   const auto load_status = LoadProtobufTextFile<configs::StaticConfig>(
       kStaticConfigFile, &static_config);

--- a/plugins/protobuf/protobuf_test.cc
+++ b/plugins/protobuf/protobuf_test.cc
@@ -4,7 +4,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
+#include <filesystem>
 #include <vector>
 
 #include "Configs/attack_behavior_config.pb.h"
@@ -16,8 +16,9 @@ namespace protobuf {
 namespace {
 
 TEST(ProtobufTest, LoadProtobufTextAttackBehaviorConfigFileTest) {
-  const std::string kAttackBehaviorConfigFile =
-      "../micromissiles-configs-data+/Attacks/default_direct_attack.pbtxt";
+  const auto kAttackBehaviorConfigFile =
+      std::filesystem::path("..") / "micromissiles-configs-data+" / "Attacks" /
+      "default_direct_attack.pbtxt";
   configs::AttackBehaviorConfig attack_behavior_config;
   const auto status = LoadProtobufTextFile<configs::AttackBehaviorConfig>(
       kAttackBehaviorConfigFile, &attack_behavior_config);
@@ -27,8 +28,9 @@ TEST(ProtobufTest, LoadProtobufTextAttackBehaviorConfigFileTest) {
 }
 
 TEST(ProtobufTest, LoadProtobufTextStaticConfigFileTest) {
-  const std::string kStaticConfigFile =
-      "../micromissiles-configs-data+/Models/micromissile.pbtxt";
+  const auto kStaticConfigFile = std::filesystem::path("..") /
+                                 "micromissiles-configs-data+" / "Models" /
+                                 "micromissile.pbtxt";
   configs::StaticConfig static_config;
   const auto status = LoadProtobufTextFile<configs::StaticConfig>(
       kStaticConfigFile, &static_config);
@@ -41,8 +43,9 @@ TEST(ProtobufTest, LoadProtobufTextStaticConfigFileTest) {
 }
 
 TEST(ProtobufTest, LoadProtobufTextSimulationConfigFileTest) {
-  const std::string kSimulationConfigFile =
-      "../micromissiles-configs-data+/Simulations/7_quadcopters.pbtxt";
+  const auto kSimulationConfigFile = std::filesystem::path("..") /
+                                     "micromissiles-configs-data+" /
+                                     "Simulations" / "7_quadcopters.pbtxt";
   configs::SimulationConfig simulation_config;
   const auto status = LoadProtobufTextFile<configs::SimulationConfig>(
       kSimulationConfigFile, &simulation_config);
@@ -52,8 +55,9 @@ TEST(ProtobufTest, LoadProtobufTextSimulationConfigFileTest) {
 }
 
 TEST(ProtobufTest, LoadProtobufTextInvalidFileTest) {
-  const std::string kSimulationConfigFile =
-      "../micromissiles-configs-data+/Simulations/invalid.pbtxt";
+  const auto kSimulationConfigFile = std::filesystem::path("..") /
+                                     "micromissiles-configs-data+" /
+                                     "Simulations" / "invalid.pbtxt";
   configs::SimulationConfig simulation_config;
   const auto status = LoadProtobufTextFile<configs::SimulationConfig>(
       kSimulationConfigFile, &simulation_config);
@@ -61,8 +65,9 @@ TEST(ProtobufTest, LoadProtobufTextInvalidFileTest) {
 }
 
 TEST(ProtobufTest, SerializeToBufferTest) {
-  const std::string kStaticConfigFile =
-      "../micromissiles-configs-data+/Models/micromissile.pbtxt";
+  const auto kStaticConfigFile = std::filesystem::path("..") /
+                                 "micromissiles-configs-data+" / "Models" /
+                                 "micromissile.pbtxt";
   configs::StaticConfig static_config;
   const auto load_status = LoadProtobufTextFile<configs::StaticConfig>(
       kStaticConfigFile, &static_config);
@@ -76,8 +81,9 @@ TEST(ProtobufTest, SerializeToBufferTest) {
 }
 
 TEST(ProtobufTest, SerializeToBufferInsufficientSizeTest) {
-  const std::string kStaticConfigFile =
-      "../micromissiles-configs-data+/Models/micromissile.pbtxt";
+  const auto kStaticConfigFile = std::filesystem::path("..") /
+                                 "micromissiles-configs-data+" / "Models" /
+                                 "micromissile.pbtxt";
   configs::StaticConfig static_config;
   const auto load_status = LoadProtobufTextFile<configs::StaticConfig>(
       kStaticConfigFile, &static_config);


### PR DESCRIPTION
Bazel test is currently failing for //protobuf:protobuf_test on my machine. I would like to know that this would be caught by CI tests.

Here is the result on my local machine for the `titan/bazel_8.4.2` branch
<img width="1825" height="529" alt="image" src="https://github.com/user-attachments/assets/e3592acf-d8e7-4ecf-976c-23f2b9f52dee" />

