### PR TITLE
[Docs] Remove table of contents from all documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ You can find the latest release [here](https://github.com/PisterLab/micromissile
 - To get started with Unity development, see the [**Development Guide**](https://pisterlab.github.io/micromissiles-unity/Development_Guide.html)
 - To learn how to build and develop the C++ plugins, see the [**Plugins Guide**](https://pisterlab.github.io/micromissiles-unity/Plugins_Guide.html)
 - To navigate and interact with the simulation, see the [**Keybinds and Controls**](https://pisterlab.github.io/micromissiles-unity/Keybinds_and_Controls.html)
-- To configure simulation settings, see the [**Simulation Configuration Guide**](https://pisterlab.github.io/micromissiles-unity/Simulation_Configuration_Guide.html)
-- To analyze simulation logs, see the [**Simulation Logging Guide**](https://pisterlab.github.io/micromissiles-unity/Simulation_Logging.html)
+- To configure simulation settings, see the [**Sim Config Guide**](https://pisterlab.github.io/micromissiles-unity/Simulation_Configuration_Guide.html)
+- To analyze simulation logs, see the [**Sim Logging Guide**](https://pisterlab.github.io/micromissiles-unity/Simulation_Logging.html)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -33,7 +33,8 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: "Home", link: "/" },
-      { text: "Simulator Overview", link: "/Simulator_Overview" },
+      { text: "Sim Overview", link: "/Simulator_Overview" },
+      { text: "Sim Config Guide", link: "/Simulation_Configuration_Guide"},
       { text: "Development Guide", link: "/Development_Guide" },
     ],
 
@@ -41,9 +42,9 @@ export default defineConfig({
       {
         text: "Documentation",
         items: [
-          { text: "Simulator Overview", link: "/Simulator_Overview" },
+          { text: "Sim Overview", link: "/Simulator_Overview" },
           { text: "Keybinds and Controls", link: "/Keybinds_and_Controls" },
-          { text: "Simulation Configuration Guide", link: "/Simulation_Configuration_Guide" },
+          { text: "Sim Config Guide", link: "/Simulation_Configuration_Guide" },
           { text: "Simulation Logging", link: "/Simulation_Logging" },
           { text: "Coverage Reports",
             items: [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -34,7 +34,7 @@ export default defineConfig({
     nav: [
       { text: "Home", link: "/" },
       { text: "Sim Overview", link: "/Simulator_Overview" },
-      { text: "Sim Config Guide", link: "/Simulation_Configuration_Guide"},
+      { text: "Sim Config Guide", link: "/Simulation_Configuration_Guide" },
       { text: "Development Guide", link: "/Development_Guide" },
     ],
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,7 +45,7 @@ export default defineConfig({
           { text: "Sim Overview", link: "/Simulator_Overview" },
           { text: "Keybinds and Controls", link: "/Keybinds_and_Controls" },
           { text: "Sim Config Guide", link: "/Simulation_Configuration_Guide" },
-          { text: "Simulation Logging", link: "/Simulation_Logging" },
+          { text: "Sim Logging", link: "/Simulation_Logging" },
           { text: "Coverage Reports",
             items: [
               { text: "EditMode Tests", link: "https://pisterlab.github.io/micromissiles-unity/coverage/editmode/Report/index.html" },

--- a/docs/Development_Guide.md
+++ b/docs/Development_Guide.md
@@ -3,10 +3,6 @@
 This guide will help you set up and run the project in development mode.
 You'll learn how to install Unity Hub, open the project, and navigate the main scene.
 
-## Table of Contents
-
-[[toc]]
-
 ## Prerequisites
 
 - A computer with internet access.

--- a/docs/Keybinds_and_Controls.md
+++ b/docs/Keybinds_and_Controls.md
@@ -2,10 +2,6 @@
 
 This guide will help you navigate and interact with the environment using your mouse and keyboard. Below are the keybindings organized into easy-to-read tables, along with detailed descriptions to enhance your experience.
 
-## Table of Contents
-
-[[toc]]
-
 ## Mouse Controls
 
 Use your mouse to control the camera's orientation and zoom level.

--- a/docs/Plugins_Guide.md
+++ b/docs/Plugins_Guide.md
@@ -2,10 +2,6 @@
 
 This guide explains how to build and develop the C++ plugins that provide core functionality for the micromissiles simulator and allow C++ code to be executed within Unity.
 
-## Table of Contents
-
-[[toc]]
-
 ## Prerequisites
 
 - A C++ compiler (GCC, Clang, or MSVC)

--- a/docs/Simulation_Configuration_Guide.md
+++ b/docs/Simulation_Configuration_Guide.md
@@ -2,10 +2,6 @@
 
 In this guide, we will explore the different types of configuration files used in the simulation and how to modify them to customize your simulation scenarios.
 
-## Table of Contents
-
-[[toc]]
-
 ## Introduction
 
 ![Simulation configuration files](./images/agent_configuration_files.png){width=80%}

--- a/docs/Simulation_Logging.md
+++ b/docs/Simulation_Logging.md
@@ -2,10 +2,6 @@
 
 This guide provides instructions on how to access and interpret the simulation logs, how they are structured by the `SimMonitor` class, and how to utilize the provided `visualize_log.py` script to analyze simulation data. Additionally, it offers guidance on creating your own scripts for custom analysis.
 
-## Table of Contents
-
-[[toc]]
-
 ## Overview
 
 ![Python simulation log visualizer](./images/sim_visualizer.png)

--- a/docs/Simulator_Overview.md
+++ b/docs/Simulator_Overview.md
@@ -6,10 +6,6 @@ In the initial phase of the project, we have implemented a simple aerodynamic mo
 Both interceptors and threats have perfect knowledge of their opponents at a configurable sensor update rate.
 While the initial positions and velocities of the threats are hard-coded for each engagement scenario, our simulator automatically clusters the threats, predicts their future positions, plans when to automatically launch the interceptors, and assigns a threat to each interceptor to pursue.
 
-## Table of Contents
-
-[[toc]]
-
 ## Introduction
 
 To minimize the engagement cost, maximize the terminal speed and agility, and simultaneously defend against multiple threats, we propose using a hierarchical air defense system (ADS), where cheap, possibly unguided "carrier interceptors" carry multiple smaller, intelligent missile interceptors as submunitions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ hero:
       text: CONTRIBUTE
       link: /Development_Guide
 features:
-  - title: Simulator Overview
+  - title: Sim Overview
     details: Explore the simulator architecture and the swarm algorithms currently implemented in the simulator.
     link: /Simulator_Overview
   - title: Keybinds and Controls
     details: Learn how to navigate and interact with the simulation environment using your keyboard and mouse.
     link: /Keybinds_and_Controls
-  - title: Simulation Configuration Guide
+  - title: Sim Config Guide
     details: Explore the different configuration files used in the simulation and how to modify them to customize your engagement scenarios.
     link: /Simulation_Configuration_Guide
   - title: Development Guide


### PR DESCRIPTION
There's no point in having a redundant TOC take up a massive amount of space when there is a navigation bar present on the side.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/63ff1679-ce20-444a-9a69-11261be0738d" />
