### PR TITLE
[Docs] Download coverage reports into individual directories

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,13 +30,12 @@ jobs:
       - name: Build documentation
         run: npm run docs:build
 
-      - name: Download coverage report
+      - name: Download coverage reports
         if: github.event_name == 'workflow_run'
         uses: actions/download-artifact@v4
         with:
           path: docs/.vitepress/dist/coverage
-          pattern: Coverage results for *
-          merge-multiple: true
+          pattern: coverage-*
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
         continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,8 +45,8 @@ jobs:
       fail-fast: false
       matrix:
         testMode:
-          - playmode
           - editmode
+          - playmode
     steps:
       - uses: actions/checkout@v4
 
@@ -75,12 +75,12 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Test results for ${{ matrix.testMode }}
+          name: test-${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Coverage results for ${{ matrix.testMode }}
+          name: coverage-${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.coveragePath }}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -48,8 +48,8 @@ export default defineConfig({
           { text: "Sim Logging", link: "/Simulation_Logging" },
           { text: "Coverage Reports",
             items: [
-              { text: "EditMode Tests", link: "https://pisterlab.github.io/micromissiles-unity/coverage/editmode/Report/index.html" },
-              { text: "PlayMode Tests", link: "https://pisterlab.github.io/micromissiles-unity/coverage/playmode/Report/index.html" }
+              { text: "EditMode Tests", link: "https://pisterlab.github.io/micromissiles-unity/coverage/coverage-editmode/Report/index.html" },
+              { text: "PlayMode Tests", link: "https://pisterlab.github.io/micromissiles-unity/coverage/coverage-playmode/Report/index.html" }
             ]
           },
           { text: "Development Guide", link: "/Development_Guide" },


### PR DESCRIPTION
As title.  This PR changes the artifact names of the uploaded coverage reports to `coverage-editmode` and `coverage-playmode`.  When downloading the artifacts to build the documentation, the coverage reports will be downloaded to individual directories, `coverage/coverage-editmode` and `coverage/coverage-playmode`.