### PR TITLE
[Chore] Hide *.meta and pbuf generated files from PR diffs in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,11 @@
 
 # Protobuf / auto-generated C# - hide in PR diffs
 Assets/Scripts/Generated/** linguist-generated=true
+
+# Build artifacts
+*.dll linguist-vendored=true
+*.so linguist-vendored=true
+*.dylib linguist-vendored=true
+
+# Unity asset files
+*.asset linguist-vendored=true


### PR DESCRIPTION
Make the PR diffs smaller & easier to review