### PR TITLE
[Actions] Clean up release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,33 +73,3 @@ jobs:
           asset_name: micromissiles-${{ github.event.workflow_run.head_branch }}-linux-x86_64.tar.gz
           asset_path: build/build-StandaloneLinux64.tar.gz
           asset_content_type: application/gzip
-
-      - name: Upload Windows plugins
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: micromissiles-plugins-${{ github.event.workflow_run.head_branch }}-windows-x86_64.tar.gz
-          asset_path: build/plugins-windows-latest.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload Darwin plugins
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: micromissiles-plugins-${{ github.event.workflow_run.head_branch }}-darwin-x86_64.tar.gz
-          asset_path: build/plugins-macos-latest.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload Linux plugins
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: micromissiles-plugins-${{ github.event.workflow_run.head_branch }}-linux-x86_64.tar.gz
-          asset_path: build/plugins-ubuntu-22.04.tar.gz
-          asset_content_type: application/gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
       - name: Validate semantic version tag
         run: |
           if [[ ! "${{ github.event.workflow_run.head_branch }}" =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Error: Branch name ${{ github.event.workflow_run.head_branch }} does not match semantic version pattern."
             exit 1
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,5 +58,3 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_branch, 'v')
     steps:
-      - name: Verify tag
+      - name: Validate semantic version tag
         run: |
           if [[ ! "${{ github.event.workflow_run.head_branch }}" =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,14 @@ jobs:
     if: |
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'refs/tags/v')
+      startsWith(github.event.workflow_run.head_branch, 'v')
     steps:
+      - name: Verify tag
+        run: |
+          if [[ ! "${{ github.event.workflow_run.head_branch }}" =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
@@ -25,18 +31,6 @@ jobs:
           latest_tag=$(git describe --tags --abbrev=0)
           echo "LATEST_TAG=${latest_tag}" >> $GITHUB_OUTPUT
 
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.get_latest_tag.outputs.LATEST_TAG }}
-          release_name: ${{ steps.get_latest_tag.outputs.LATEST_TAG }}
-          body_path: RELEASE.md
-          draft: false
-          prerelease: false
-
       - uses: actions/download-artifact@v4
         with:
           path: build
@@ -44,32 +38,25 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Upload Windows release assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: micromissiles-${{ github.event.workflow_run.head_branch }}-windows-x86_64.zip
-          asset_path: build/build-StandaloneWindows64.zip
-          asset_content_type: application/zip
+      - name: Rename build artifacts
+        run: |
+          mv build/build-StandaloneWindows64.zip build/micromissiles-${{ github.event.workflow_run.head_branch }}-windows-x86_64.zip
+          mv build/build-StandaloneOSX.tar.gz build/micromissiles-${{ github.event.workflow_run.head_branch }}-darwin-x86_64.tar.gz
+          mv build/build-StandaloneLinux64.tar.gz build/micromissiles-${{ github.event.workflow_run.head_branch }}-linux-x86_64.tar.gz
 
-      - name: Upload Darwin release assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: micromissiles-${{ github.event.workflow_run.head_branch }}-darwin-x86_64.tar.gz
-          asset_path: build/build-StandaloneOSX.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload Linux release assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: micromissiles-${{ github.event.workflow_run.head_branch }}-linux-x86_64.tar.gz
-          asset_path: build/build-StandaloneLinux64.tar.gz
-          asset_content_type: application/gzip
+          tag_name: ${{ steps.get_latest_tag.outputs.LATEST_TAG }}
+          name: ${{ steps.get_latest_tag.outputs.LATEST_TAG }}
+          body_path: RELEASE.md
+          files: |
+            build/micromissiles-${{ github.event.workflow_run.head_branch }}-windows-x86_64.zip
+            build/micromissiles-${{ github.event.workflow_run.head_branch }}-darwin-x86_64.tar.gz
+            build/micromissiles-${{ github.event.workflow_run.head_branch }}-linux-x86_64.tar.gz
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,8 @@ jobs:
 
       - name: Create release
         uses: softprops/action-gh-release@v2
-        if: github.ref_type == 'tag'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.get_latest_tag.outputs.LATEST_TAG }}
           name: ${{ steps.get_latest_tag.outputs.LATEST_TAG }}


### PR DESCRIPTION
As title.  Some changes to the release action are:
1. The plugins are already checked into the repository and are distributed within the simulator application, so there is no need to explicitly upload them in a separate release asset.
2. Use `softprops/action-gh-release@v2` to handle creating the release, generating release notes, and uploading the release assets.
3. Add a verification step to ensure that the release is occuring on a tag that matches the regex pattern `v[0-9]+\.[0-9]+\.[0-9]+`.