### PR TITLE
[Unity] Ignore generated scripts in code coverage reports

### DIFF
--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -17,6 +17,11 @@
                 "value": "{\"m_Value\":\"{ProjectPath}\"}"
             },
             {
+                "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "PathsToExclude",
+                "value": "{\"m_Value\":\"{ProjectPath}/Assets/Scripts/Generated/**\"}"
+            },
+            {
                 "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "EnableCodeCoverage",
                 "value": "{\"m_Value\":true}"


### PR DESCRIPTION
As title.

Lol at the coverage report history:
<img width="1517" height="149" alt="image" src="https://github.com/user-attachments/assets/05ed2894-abbf-4587-bb24-ff75bcc4ea44" />
