### PR TITLE
[Gemini] Disable Gemini pull request summary

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,11 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true
+    include_drafts: true
+ignore_patterns: []


### PR DESCRIPTION
Disable Gemini from posting a pull request summary whenever a pull request is opened.  The summary should be in the description box of the PR and should be ideally human-written for conciseness and helpfulness.

https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#config.yaml-example for how to configure Gemini for Github.