### PR TITLE
[Actions] Free disk space before building

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Free disk space
-        uses: jlumbroso/free-disk-space-action@v1.3.1
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space-action@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false # Unity Builder uses Docker.
+          swap-storage: false
+
       - uses: actions/cache@v4
         with:
           path: Library


### PR DESCRIPTION
In many `Build` actions, we see the following errors when trying to build for Windows or Mac:
```
docker: failed to register layer: write /opt/unity/Editor/Data/il2cpp/external/mono/mono/metadata/jit-info.c: no space left on device
```
```
docker: failed to register layer: write /opt/unity/Editor/Data/Tools/libRL.so: no space left on device
```

An easy solution is to free up disk space before building the Unity standalone binary because we do not need a lot of the pre-installed tools on the Ubuntu runners.

Example run on `master` without this change: https://github.com/PisterLab/micromissiles-unity/actions/runs/20015597125
After this change: https://github.com/PisterLab/micromissiles-unity/actions/runs/20017608810 (note around 27 GB of disk space was freed!)