### PR TITLE
[Actions] Ignore generated scripts in code coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,7 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
-          coverageOptions: "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+bamlab.*;pathFilters:-Assets/Scripts/Generated/**"
+          coverageOptions: "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+bamlab.*,-bamlab.generated"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,7 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
-          coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+bamlab.*'
+          coverageOptions: "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+bamlab.*;pathFilters:+Assets/Scripts/Generated/**"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,7 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
-          coverageOptions: "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+bamlab.*;pathFilters:+Assets/Scripts/Generated/**"
+          coverageOptions: "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+bamlab.*;pathFilters:-Assets/Scripts/Generated/**"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,7 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
-          coverageOptions: "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+bamlab.*,-bamlab.generated"
+          coverageOptions: "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+bamlab.micromissiles"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/Assets/Scripts/Generated/bamlab.generated.asmdef
+++ b/Assets/Scripts/Generated/bamlab.generated.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "bamlab.generated"
+}

--- a/Assets/Scripts/Generated/bamlab.generated.asmdef.meta
+++ b/Assets/Scripts/Generated/bamlab.generated.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cb0a00e4d63c64b1eb61f9a4fac21d7b
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/bamlab.micromissiles.asmdef
+++ b/Assets/Scripts/bamlab.micromissiles.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "",
     "references": [
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
-        "GUID:c668b7a00ffe56a498ddb1fc9f96f4e6"
+        "GUID:c668b7a00ffe56a498ddb1fc9f96f4e6",
+        "GUID:cb0a00e4d63c64b1eb61f9a4fac21d7b"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Tests/EditMode/bamlab.test.editmode.asmdef
+++ b/Assets/Tests/EditMode/bamlab.test.editmode.asmdef
@@ -5,7 +5,8 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "bamlab.micromissiles",
-        "bamlab.test"
+        "bamlab.test",
+        "bamlab.generated"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/Tests/PlayMode/bamlab.test.playmode.asmdef
+++ b/Assets/Tests/PlayMode/bamlab.test.playmode.asmdef
@@ -5,7 +5,8 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "bamlab.micromissiles",
-        "bamlab.test"
+        "bamlab.test",
+        "bamlab.generated"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Tests/bamlab.test.asmdef
+++ b/Assets/Tests/bamlab.test.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "bamlab.micromissiles"
+        "bamlab.micromissiles",
+        "bamlab.generated"
     ],
     "includePlatforms": [
         "Editor"

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -4,7 +4,7 @@
             {
                 "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "IncludeAssemblies",
-                "value": "{\"m_Value\":\"bamlab.micromissiles,bamlab.test\"}"
+                "value": "{\"m_Value\":\"bamlab.micromissiles\"}"
             },
             {
                 "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -19,11 +19,16 @@
             {
                 "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "PathsToExclude",
-                "value": "{\"m_Value\":\"{ProjectPath}/Assets/Scripts/Generated/**\"}"
+                "value": "{\"m_Value\":\"\"}"
             },
             {
                 "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "EnableCodeCoverage",
+                "value": "{\"m_Value\":true}"
+            },
+            {
+                "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "GenerateAdditionalMetrics",
                 "value": "{\"m_Value\":true}"
             }
         ]


### PR DESCRIPTION
As title.  Currently, code coverage includes information about scripts in the `Assets/Scripts/Generated` directory, which is unnecessary.