### PR TITLE
[Joseph] Implemented Fuzzy C Means Clustering

### DIFF
--- a/Assets/Scripts/Algorithms/Clustering/Cluster.cs
+++ b/Assets/Scripts/Algorithms/Clustering/Cluster.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -6,13 +7,35 @@ public class Cluster : HierarchicalBase {
   [SerializeField]
   private Vector3 _centroid;
 
+  private readonly Dictionary<IHierarchical, float> _memberships = new Dictionary<IHierarchical, float>();
+
   public Vector3 Centroid {
     get => _centroid;
     set => _centroid = value;
   }
 
+  public IReadOnlyDictionary<IHierarchical, float> Memberships => _memberships;
+
   public int Size => ActiveSubHierarchicals.Count();
   public bool IsEmpty => Size == 0;
+
+  public float GetMembership(IHierarchical hierarchical) {
+    if (hierarchical == null) {
+      return 0f;
+    }
+    return _memberships.TryGetValue(hierarchical, out float membership) ? membership : 0f;
+  }
+
+  internal void SetMembership(IHierarchical hierarchical, float membership) {
+    if (hierarchical == null) {
+      return;
+    }
+    _memberships[hierarchical] = Mathf.Clamp01(membership);
+  }
+
+  internal void ClearMemberships() {
+    _memberships.Clear();
+  }
 
   public float Radius() {
     if (IsEmpty) {

--- a/Assets/Scripts/Algorithms/Clustering/FuzzyCMeansClusterer.cs
+++ b/Assets/Scripts/Algorithms/Clustering/FuzzyCMeansClusterer.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+// The fuzzy c-means clusterer performs fuzzy c-means clustering.
+public class FuzzyCMeansClusterer : ClustererBase {
+  // Default maximum number of iterations.
+  protected const int _defaultMaxNumIterations = 50;
+
+  // Default fuzziness parameter (m).
+  protected const float _defaultFuzziness = 2f;
+
+  // Default convergence threshold.
+  protected const float _defaultEpsilon = 1e-3f;
+
+  private const float _distanceEpsilon = 1e-6f;
+
+  // Number of clusters.
+  private readonly int _k;
+
+  // Fuzziness parameter (m).
+  private readonly float _fuzziness;
+
+  // Maximum number of iterations.
+  private readonly int _maxNumIterations;
+
+  // Convergence threshold.
+  private readonly float _epsilon;
+
+  public FuzzyCMeansClusterer(int k)
+      : this(k, _defaultFuzziness, _defaultMaxNumIterations, _defaultEpsilon) {}
+
+  public FuzzyCMeansClusterer(int k, float fuzziness, int maxNumIterations, float epsilon) {
+    if (k <= 0) {
+      throw new ArgumentOutOfRangeException(nameof(k), "Number of clusters must be positive.");
+    }
+    if (fuzziness <= 1f) {
+      throw new ArgumentOutOfRangeException(nameof(fuzziness), "Fuzziness must be greater than 1.");
+    }
+    if (maxNumIterations <= 0) {
+      throw new ArgumentOutOfRangeException(nameof(maxNumIterations),
+                                            "Maximum iterations must be positive.");
+    }
+    if (epsilon <= 0f) {
+      throw new ArgumentOutOfRangeException(nameof(epsilon), "Epsilon must be positive.");
+    }
+    _k = k;
+    _fuzziness = fuzziness;
+    _maxNumIterations = maxNumIterations;
+    _epsilon = epsilon;
+  }
+
+  // Generate the clusters from the list of hierarchical objects.
+  public override List<Cluster> Cluster(IEnumerable<IHierarchical> hierarchicals) {
+    return ClusterFuzzy(hierarchicals).Clusters;
+  }
+
+  public FuzzyCMeansResult ClusterFuzzy(IEnumerable<IHierarchical> hierarchicals,
+                                        IReadOnlyList<Vector3> initialCentroids = null,
+                                        float membershipThreshold = 1f,
+                                        int maxMembershipsPerPoint = 1) {
+    if (hierarchicals == null) {
+      return new FuzzyCMeansResult {
+        Points = new List<IHierarchical>(),
+        Centroids = new List<Vector3>(),
+        Memberships = new float[0, 0],
+        Clusters = new List<Cluster>(),
+      };
+    }
+
+    if (membershipThreshold < 0f || membershipThreshold > 1f) {
+      throw new ArgumentOutOfRangeException(
+          nameof(membershipThreshold), "Membership threshold must be between 0 and 1.");
+    }
+    if (maxMembershipsPerPoint <= 0) {
+      throw new ArgumentOutOfRangeException(
+          nameof(maxMembershipsPerPoint), "Max memberships per point must be positive.");
+    }
+
+    List<IHierarchical> hierarchicalsList = hierarchicals.ToList();
+    if (hierarchicalsList.Count == 0) {
+      return new FuzzyCMeansResult {
+        Points = new List<IHierarchical>(),
+        Centroids = new List<Vector3>(),
+        Memberships = new float[0, 0],
+        Clusters = new List<Cluster>(),
+      };
+    }
+
+    // Validate that k is not greater than the number of hierarchical objects.
+    if (_k > hierarchicalsList.Count) {
+      throw new InvalidOperationException(
+          $"Cannot create {_k} clusters from {hierarchicalsList.Count} hierarchical objects.");
+    }
+
+    List<Vector3> positions = hierarchicalsList.Select(hierarchical => hierarchical.Position)
+                                   .ToList();
+    var centroids = new List<Vector3>(_k);
+    if (initialCentroids != null && initialCentroids.Count == _k) {
+      centroids.AddRange(initialCentroids);
+    } else {
+      var indices = new List<int>(positions.Count);
+      for (int i = 0; i < positions.Count; ++i) {
+        indices.Add(i);
+      }
+      for (int i = 0; i < _k; ++i) {
+        int j = UnityEngine.Random.Range(i, indices.Count);
+        (indices[i], indices[j]) = (indices[j], indices[i]);
+        centroids.Add(positions[indices[i]]);
+      }
+    }
+
+    float[,] memberships = new float[positions.Count, _k];
+    UpdateMemberships(positions, centroids, memberships, _fuzziness);
+
+    bool converged = false;
+    int numIteration = 0;
+    while (!converged && numIteration < _maxNumIterations) {
+      List<Vector3> newCentroids = UpdateCentroids(positions, memberships, _fuzziness, _k);
+
+      float maxShift = 0f;
+      for (int clusterIndex = 0; clusterIndex < _k; ++clusterIndex) {
+        float shift = Vector3.Distance(centroids[clusterIndex], newCentroids[clusterIndex]);
+        if (shift > maxShift) {
+          maxShift = shift;
+        }
+      }
+      centroids = newCentroids;
+
+      UpdateMemberships(positions, centroids, memberships, _fuzziness);
+
+      converged = maxShift <= _epsilon;
+      ++numIteration;
+    }
+
+    List<Vector3> centroidSnapshot = centroids.ToList();
+    int cappedMaxMembershipsPerPoint = Mathf.Min(maxMembershipsPerPoint, _k);
+    List<Cluster> clusters = BuildClusters(hierarchicalsList, centroids, memberships,
+                                           membershipThreshold, cappedMaxMembershipsPerPoint);
+    return new FuzzyCMeansResult {
+      Points = hierarchicalsList,
+      Centroids = centroidSnapshot,
+      Memberships = memberships,
+      Clusters = clusters,
+    };
+  }
+
+  private struct MembershipEntry {
+    public int Index;
+    public float Value;
+  }
+
+  private static List<Cluster> BuildClusters(IReadOnlyList<IHierarchical> hierarchicals,
+                                             IReadOnlyList<Vector3> centroids,
+                                             float[,] memberships,
+                                             float membershipThreshold,
+                                             int maxMembershipsPerPoint) {
+    int numClusters = centroids.Count;
+    int numPoints = hierarchicals.Count;
+    var clusters = new List<Cluster>(numClusters);
+    for (int clusterIndex = 0; clusterIndex < numClusters; ++clusterIndex) {
+      clusters.Add(new Cluster { Centroid = centroids[clusterIndex] });
+    }
+
+    var clusterSizes = new int[numClusters];
+    var membershipsForPoint = new List<MembershipEntry>(numClusters);
+    for (int pointIndex = 0; pointIndex < numPoints; ++pointIndex) {
+      membershipsForPoint.Clear();
+
+      float bestMembership = memberships[pointIndex, 0];
+      int bestIndex = 0;
+      for (int clusterIndex = 0; clusterIndex < numClusters; ++clusterIndex) {
+        float membership = memberships[pointIndex, clusterIndex];
+        if (membership > bestMembership) {
+          bestMembership = membership;
+          bestIndex = clusterIndex;
+        }
+        if (membership >= membershipThreshold) {
+          membershipsForPoint.Add(
+              new MembershipEntry { Index = clusterIndex, Value = membership });
+        }
+      }
+
+      if (membershipsForPoint.Count == 0) {
+        membershipsForPoint.Add(
+            new MembershipEntry { Index = bestIndex, Value = bestMembership });
+      } else if (membershipsForPoint.Count > maxMembershipsPerPoint) {
+        membershipsForPoint.Sort((left, right) => right.Value.CompareTo(left.Value));
+        membershipsForPoint.RemoveRange(maxMembershipsPerPoint,
+                                        membershipsForPoint.Count - maxMembershipsPerPoint);
+      }
+
+      foreach (var membership in membershipsForPoint) {
+        Cluster cluster = clusters[membership.Index];
+        cluster.AddSubHierarchical(hierarchicals[pointIndex]);
+        cluster.SetMembership(hierarchicals[pointIndex], membership.Value);
+        ++clusterSizes[membership.Index];
+      }
+    }
+
+    for (int clusterIndex = 0; clusterIndex < numClusters; ++clusterIndex) {
+      if (clusterSizes[clusterIndex] > 0) {
+        continue;
+      }
+      int bestPointIndex = 0;
+      float bestMembership = memberships[0, clusterIndex];
+      for (int pointIndex = 1; pointIndex < numPoints; ++pointIndex) {
+        float membership = memberships[pointIndex, clusterIndex];
+        if (membership > bestMembership) {
+          bestMembership = membership;
+          bestPointIndex = pointIndex;
+        }
+      }
+      Cluster cluster = clusters[clusterIndex];
+      cluster.AddSubHierarchical(hierarchicals[bestPointIndex]);
+      cluster.SetMembership(hierarchicals[bestPointIndex], bestMembership);
+      ++clusterSizes[clusterIndex];
+    }
+
+    foreach (var cluster in clusters) {
+      cluster.Recenter();
+    }
+    return clusters;
+  }
+
+  private static void UpdateMemberships(IReadOnlyList<Vector3> positions,
+                                        IReadOnlyList<Vector3> centroids,
+                                        float[,] memberships,
+                                        float fuzziness) {
+    int numPoints = positions.Count;
+    int numClusters = centroids.Count;
+    float exponent = 2f / (fuzziness - 1f);
+
+    var distances = new float[numClusters];
+    for (int pointIndex = 0; pointIndex < numPoints; ++pointIndex) {
+      int zeroCount = 0;
+      for (int clusterIndex = 0; clusterIndex < numClusters; ++clusterIndex) {
+        float distance = Vector3.Distance(positions[pointIndex], centroids[clusterIndex]);
+        distances[clusterIndex] = distance;
+        if (distance <= _distanceEpsilon) {
+          ++zeroCount;
+        }
+      }
+
+      if (zeroCount > 0) {
+        float membership = 1f / zeroCount;
+        for (int clusterIndex = 0; clusterIndex < numClusters; ++clusterIndex) {
+          memberships[pointIndex, clusterIndex] =
+              distances[clusterIndex] <= _distanceEpsilon ? membership : 0f;
+        }
+        continue;
+      }
+
+      for (int clusterIndex = 0; clusterIndex < numClusters; ++clusterIndex) {
+        float sum = 0f;
+        float distance = distances[clusterIndex];
+        for (int otherIndex = 0; otherIndex < numClusters; ++otherIndex) {
+          float ratio = distance / distances[otherIndex];
+          sum += Mathf.Pow(ratio, exponent);
+        }
+        memberships[pointIndex, clusterIndex] = 1f / sum;
+      }
+    }
+  }
+
+  private static List<Vector3> UpdateCentroids(IReadOnlyList<Vector3> positions,
+                                               float[,] memberships,
+                                               float fuzziness,
+                                               int numClusters) {
+    int numPoints = positions.Count;
+    var centroids = new List<Vector3>(numClusters);
+    for (int clusterIndex = 0; clusterIndex < numClusters; ++clusterIndex) {
+      Vector3 numerator = Vector3.zero;
+      float denominator = 0f;
+      for (int pointIndex = 0; pointIndex < numPoints; ++pointIndex) {
+        float weight = Mathf.Pow(memberships[pointIndex, clusterIndex], fuzziness);
+        numerator += weight * positions[pointIndex];
+        denominator += weight;
+      }
+
+      if (denominator <= Mathf.Epsilon) {
+        int randomIndex = UnityEngine.Random.Range(0, numPoints);
+        centroids.Add(positions[randomIndex]);
+      } else {
+        centroids.Add(numerator / denominator);
+      }
+    }
+    return centroids;
+  }
+}

--- a/Assets/Scripts/Algorithms/Clustering/FuzzyCMeansClusterer.cs.meta
+++ b/Assets/Scripts/Algorithms/Clustering/FuzzyCMeansClusterer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8002c8b349e4f476c821196bab88cfe7

--- a/Assets/Scripts/Algorithms/Clustering/FuzzyCMeansResult.cs
+++ b/Assets/Scripts/Algorithms/Clustering/FuzzyCMeansResult.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+// Result of a fuzzy c-means clustering run.
+public class FuzzyCMeansResult {
+  public IReadOnlyList<IHierarchical> Points { get; init; }
+  public IReadOnlyList<Vector3> Centroids { get; init; }
+  public float[,] Memberships { get; init; }
+  public List<Cluster> Clusters { get; init; }
+}

--- a/Assets/Scripts/Algorithms/Clustering/FuzzyCMeansResult.cs.meta
+++ b/Assets/Scripts/Algorithms/Clustering/FuzzyCMeansResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: adc3f0f00c0c14a8b8733c128ea2ce79

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -7,17 +7,26 @@ using UnityEngine;
 // It implements the singleton pattern to ensure that only one instance exists.
 public class IADS : MonoBehaviour {
   // Hierarchy parameters.
-  private const float _hierarchyUpdatePeriod = 5f;
-  private const float _coverageFactor = 1f;
+  private const float _hierarchyUpdatePeriod = 5f; // Var Def: seconds between top-level swarm rebuilds.
+  private const float _subHierarchyUpdatePeriod = 1f; // Var Def: seconds between sub-hierarchy refreshes.
+  private const float _coverageFactor = 1f; // Var Def: scales number of swarms vs launchers.
+
+  private const float _fuzzyFuzziness = 2f; // Var Def: FCM fuzziness (m) for swarms.
+  private const int _fuzzyMaxNumIterations = 25; // Var Def: FCM iteration cap for swarms.
+  private const float _fuzzyEpsilon = 1e-2f; // Var Def: FCM convergence threshold for swarms.
+  private const float _swarmMembershipThreshold = 0.35f; // Var Def: membership cutoff for swarm overlap.
+  private const int _swarmMaxMembershipsPerThreat = 2; // Var Def: max swarms a threat can belong to.
 
   // The IADS only manages the launchers in the top level of the interceptor hierarchy.
-  private List<IHierarchical> _launchers = new List<IHierarchical>();
+  private List<IHierarchical> _launchers = new List<IHierarchical>(); // Var Def: top-level launcher nodes.
 
   // Coroutine to perform the maintain the agent hierarchy.
-  private Coroutine _hierarchyCoroutine;
+  private Coroutine _hierarchyCoroutine; // Var Def: coroutine handle for hierarchy updates.
+  private float _nextHierarchyUpdateTime; // Var Def: next scheduled swarm rebuild time.
+  private float _nextSubHierarchyUpdateTime; // Var Def: next scheduled sub-hierarchy refresh time.
 
   // List of threats waiting to be incorporated into the hierarchy.
-  private List<IHierarchical> _newThreats = new List<IHierarchical>();
+  private List<IHierarchical> _newThreats = new List<IHierarchical>(); // Var Def: threats pending incorporation.
 
   public static IADS Instance { get; private set; }
 
@@ -46,7 +55,7 @@ public class IADS : MonoBehaviour {
   }
 
   private void RegisterSimulationStarted() {
-    _hierarchyCoroutine = StartCoroutine(HierarchyManager(_hierarchyUpdatePeriod));
+    _hierarchyCoroutine = StartCoroutine(HierarchyManager(_subHierarchyUpdatePeriod));
   }
 
   private void RegisterSimulationEnded() {
@@ -73,19 +82,47 @@ public class IADS : MonoBehaviour {
   }
 
   private IEnumerator HierarchyManager(float period) {
+    _nextHierarchyUpdateTime = Time.time;
+    _nextSubHierarchyUpdateTime = Time.time;
     while (true) {
-      if (_newThreats.Count != 0) {
+      float now = Time.time;
+      if (now >= _nextHierarchyUpdateTime) {
         BuildHierarchy();
+        _nextHierarchyUpdateTime = now + _hierarchyUpdatePeriod;
+      }
+      if (now >= _nextSubHierarchyUpdateTime) {
+        RefreshSubHierarchies();
+        _nextSubHierarchyUpdateTime = now + _subHierarchyUpdatePeriod;
       }
       yield return new WaitForSeconds(period);
     }
   }
 
   private void BuildHierarchy() {
-    // TODO(titan): The clustering algorithm should be aware of the capacity of the launcher.
-    var swarmClusterer = new KMeansClusterer(Mathf.RoundToInt(_launchers.Count / _coverageFactor));
-    List<Cluster> swarms = swarmClusterer.Cluster(_newThreats);
+    if (_launchers.Count == 0) {
+      _newThreats.Clear();
+      return;
+    }
+
+    List<IHierarchical> activeThreats = CollectActiveThreats();
+    if (activeThreats.Count == 0) {
+      _newThreats.Clear();
+      return;
+    }
+
+    int k = Mathf.RoundToInt(_launchers.Count / _coverageFactor);
+    k = Mathf.Clamp(k, 1, activeThreats.Count);
+
+    var swarmClusterer =
+        new FuzzyCMeansClusterer(k, _fuzzyFuzziness, _fuzzyMaxNumIterations, _fuzzyEpsilon);
+    List<Vector3> initialCentroids = GetExistingSwarmCentroids(k);
+    FuzzyCMeansResult swarmResult = swarmClusterer.ClusterFuzzy(
+        activeThreats, initialCentroids, _swarmMembershipThreshold, _swarmMaxMembershipsPerThreat);
+    List<Cluster> swarms = swarmResult.Clusters;
     _newThreats.Clear();
+    if (swarms.Count == 0) {
+      return;
+    }
 
     // Assign one swarm to each launcher.
     var swarmToLauncherAssignment =
@@ -105,6 +142,53 @@ public class IADS : MonoBehaviour {
       // TODO(titan): The threats would normally target the aircraft carrier within the strike
       // group.
       AssignTarget(assignment.Second, assignment.First);
+    }
+  }
+
+  private List<IHierarchical> CollectActiveThreats() {
+    var threats = new HashSet<IHierarchical>();
+    foreach (var launcher in _launchers) {
+      if (launcher.Target == null || launcher.Target.IsTerminated) {
+        continue;
+      }
+      foreach (var threat in launcher.Target.ActiveSubHierarchicals) {
+        threats.Add(threat);
+      }
+    }
+    foreach (var threat in _newThreats) {
+      if (threat == null || threat.IsTerminated) {
+        continue;
+      }
+      threats.Add(threat);
+    }
+    return threats.ToList();
+  }
+
+  private List<Vector3> GetExistingSwarmCentroids(int k) {
+    var centroids = new List<Vector3>(k);
+    foreach (var launcher in _launchers) {
+      if (launcher.Target is Cluster cluster) {
+        centroids.Add(cluster.Centroid);
+      }
+    }
+    return centroids.Count == k ? centroids : null;
+  }
+
+  private void RefreshSubHierarchies() {
+    foreach (var launcher in _launchers) {
+      if (launcher is not HierarchicalAgent hierarchicalAgent) {
+        continue;
+      }
+      if (hierarchicalAgent.Target == null || hierarchicalAgent.Target.IsTerminated) {
+        continue;
+      }
+      if (hierarchicalAgent.Agent is not IInterceptor interceptor) {
+        continue;
+      }
+      if (interceptor.CapacityPerSubInterceptor <= 0) {
+        continue;
+      }
+      hierarchicalAgent.RefreshClusters(interceptor.CapacityPerSubInterceptor);
     }
   }
 

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -7,6 +7,12 @@ using UnityEngine;
 // It implements the singleton pattern to ensure that only one instance exists.
 public class IADS : MonoBehaviour {
   // Hierarchy parameters.
+
+
+  //TODO Joseph: (solution 1) implement variable update period. Higher frequency on lower level
+  //TODO Joseph: (solution 2) implement drift boundary detection.
+
+
   private const float _hierarchyUpdatePeriod = 5f; // Var Def: seconds between top-level swarm rebuilds.
   private const float _subHierarchyUpdatePeriod = 1f; // Var Def: seconds between sub-hierarchy refreshes.
   private const float _coverageFactor = 1f; // Var Def: scales number of swarms vs launchers.
@@ -31,6 +37,8 @@ public class IADS : MonoBehaviour {
   public static IADS Instance { get; private set; }
 
   public IReadOnlyList<IHierarchical> Launchers => _launchers.AsReadOnly();
+
+  
 
   private void Awake() {
     if (Instance != null && Instance != this) {


### PR DESCRIPTION
Implemented fuzzy c‑means clustering with membership overlap and multi‑rate hierarchy refresh so swarms and sub‑clusters update over time and can share threats for redundancy. Accounts for drifting threats as well (interceptor to interceptor, swarm to swarm, or launcher to launcher)

1. Added new clustering output type and logic for warm‑starts + overlap in FuzzyCMeansResult.cs and FuzzyCMeansClusterer.cs.
2. Stored per‑threat membership weights on clusters in Cluster.cs.
3. Swapped hierarchy clustering to FCM and added periodic refresh/rebuild in HierarchicalBase.cs.
4. Rebuilt top‑level swarms every 5s and refreshed sub‑hierarchies every 1s in IADS.cs.

Files added:
1. FuzzyCMeansResult.cs
2. FuzzyCMeansClusterer.cs

Files modified
1. Cluster.cs
2. HierarchicalBase.cs
3. IADS.cs

<img width="2761" height="959" alt="Screenshot 2026-01-14 at 11 49 24 PM" src="https://github.com/user-attachments/assets/40d3d373-9f1f-49b3-8774-e0a009b1a8cc" />
<img width="2761" height="959" alt="Screenshot 2026-01-14 at 11 50 48 PM" src="https://github.com/user-attachments/assets/ae12f046-610c-4d6d-a260-e9892667634b" />
<img width="2761" height="959" alt="Screenshot 2026-01-14 at 11 51 31 PM" src="https://github.com/user-attachments/assets/c0a3ddbb-8d02-4967-8a89-1eecd956a272" />
