### PR TITLE
[Reassignment] Configure launchers to be not reassignable

### DIFF
--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -58,11 +58,11 @@ public class IADS : MonoBehaviour {
     _newThreats.Clear();
   }
 
-  public void RegisterNewLauncher(IInterceptor interceptor) {
-    if (interceptor.HierarchicalAgent != null) {
-      interceptor.OnAssignSubInterceptor += AssignSubInterceptor;
-      interceptor.OnReassignTarget += ReassignTarget;
-      _launchers.Add(interceptor.HierarchicalAgent);
+  public void RegisterNewLauncher(IInterceptor launcher) {
+    if (launcher.HierarchicalAgent != null) {
+      launcher.OnAssignSubInterceptor += AssignSubInterceptor;
+      launcher.OnReassignTarget += ReassignTarget;
+      _launchers.Add(launcher.HierarchicalAgent);
     }
   }
 

--- a/Assets/Scripts/Interceptors/IInterceptor.cs
+++ b/Assets/Scripts/Interceptors/IInterceptor.cs
@@ -45,6 +45,9 @@ public interface IInterceptor : IAgent {
   // Number of sub-interceptors remaining.
   int NumSubInterceptorsRemaining { get; }
 
+  // If true, the interceptor can be reassigned to other targets.
+  bool IsReassignable { get; }
+
   // Assign a new target to the sub-interceptor.
   void AssignSubInterceptor(IInterceptor subInterceptor);
 

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -117,7 +117,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     // Check whether the interceptor has a target. If not, request a new target from the parent
     // interceptor.
     if (HierarchicalAgent.Target == null || HierarchicalAgent.Target.IsTerminated) {
-      RequestReassignment();
+      RequestReassignment(this);
     }
 
     // Check whether any targets are escaping from the interceptor.
@@ -131,7 +131,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
         OnReassignTarget?.Invoke(target);
       }
       if (escapingTargets.Count == targetHierarchicals.Count) {
-        RequestReassignment();
+        RequestReassignment(this);
       }
     }
 
@@ -261,13 +261,13 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
       OnReassignTarget?.Invoke(targetHierarchical);
     }
 
-    RequestReassignment();
+    RequestReassignment(interceptor);
   }
 
-  private void RequestReassignment() {
-    if (IsReassignable) {
+  private void RequestReassignment(IInterceptor interceptor) {
+    if (interceptor.IsReassignable) {
       // Request a new target from the parent interceptor.
-      OnAssignSubInterceptor?.Invoke(this);
+      OnAssignSubInterceptor?.Invoke(interceptor);
     }
   }
 

--- a/Assets/Scripts/Interceptors/LauncherBase.cs
+++ b/Assets/Scripts/Interceptors/LauncherBase.cs
@@ -9,6 +9,9 @@ public abstract class LauncherBase : CarrierBase {
   // Launchers cannot pursue threats.
   public override bool IsPursuer => false;
 
+  // Launchers cannot be reassigned to other targets and rely on threat reassignment only.
+  public override bool IsReassignable => false;
+
   protected override void Awake() {
     base.Awake();
 


### PR DESCRIPTION
Resolves #196.  Once a launcher has terminated all of its assigned targets, it might get reassigned by the IADS to pursue some other launcher's targets.  This causes it to then start launching carrier interceptors across the map.  Ideally, launchers cannot be reassigned to new targets and rely on threat assignment only to receive new targets.  See #196 for an example simulation configuration.