### PR TITLE
[Reassignment] Interceptor reassignment optimizes for intercept speed

### DIFF
--- a/Assets/Scripts/Agents/AgentBase.cs
+++ b/Assets/Scripts/Agents/AgentBase.cs
@@ -115,7 +115,9 @@ public class AgentBase : MonoBehaviour, IAgent {
 
   public float MaxNormalAcceleration() {
     float maxReferenceNormalAcceleration =
-        (StaticConfig.AccelerationConfig?.MaxReferenceNormalAcceleration ?? 0) * Constants.kGravity;
+        (StaticConfig.AccelerationConfig?.MaxReferenceNormalAcceleration ??
+         float.PositiveInfinity) *
+        Constants.kGravity;
     float referenceSpeed = StaticConfig.AccelerationConfig?.ReferenceSpeed ?? 1;
     return Mathf.Pow(Speed / referenceSpeed, 2) * maxReferenceNormalAcceleration;
   }

--- a/Assets/Scripts/Assignment/MaxSpeedAssignment.cs
+++ b/Assets/Scripts/Assignment/MaxSpeedAssignment.cs
@@ -16,25 +16,7 @@ public class MaxSpeedAssignment : CostBasedAssignment {
     }
 
     IAgent agent = hierarchicalAgent.Agent;
-    // The speed decays exponentially with the traveled distance and with the bearing change.
-    float distanceTimeConstant = 2 * (agent.StaticConfig.BodyConfig?.Mass ?? 0) /
-                                 (Constants.CalculateAirDensityAtAltitude(agent.Position.y) *
-                                  (agent.StaticConfig.LiftDragConfig?.DragCoefficient ?? 0) *
-                                  (agent.StaticConfig.BodyConfig?.CrossSectionalArea ?? 0));
-    float angleTimeConstant = agent.StaticConfig.LiftDragConfig?.LiftDragRatio ?? 1;
-    // During the turn, the minimum radius dictates the minimum distance needed to make the turn.
-    float minTurningRadius = agent.Velocity.sqrMagnitude / agent.MaxNormalAcceleration();
-
-    Vector3 directionToTarget = target.Position - agent.Position;
-    float distanceToTarget = directionToTarget.magnitude;
-    float angleToTarget = Vector3.Angle(agent.Velocity, directionToTarget) * Mathf.Deg2Rad;
-    // The fractional speed is the product of the fractional speed after traveling the distance and
-    // of the fractional speed after turning.
-    float fractionalSpeed =
-        Mathf.Exp(-((distanceToTarget + angleToTarget * minTurningRadius) / distanceTimeConstant +
-                    angleToTarget / angleTimeConstant));
-    // Prevent division by zero.
-    fractionalSpeed = Mathf.Max(fractionalSpeed, _minFractionalSpeed);
-    return agent.Speed / fractionalSpeed;
+    float fractionalSpeed = FractionalSpeed.Calculate(agent, target.Position);
+    return agent.Speed / Mathf.Max(fractionalSpeed, _minFractionalSpeed);
   }
 }

--- a/Assets/Scripts/Escape/SpeedEscapeDetector.cs
+++ b/Assets/Scripts/Escape/SpeedEscapeDetector.cs
@@ -5,9 +5,6 @@ using UnityEngine;
 // The speed escape detector checks whether the agent has a speed greater than the threat's when it
 // has navigated to the threat's current position.
 public class SpeedEscapeDetector : EscapeDetectorBase {
-  // Minimum fractional speed to prevent division by zero.
-  private const float _minFractionalSpeed = 1e-6f;
-
   public SpeedEscapeDetector(IAgent agent) : base(agent) {}
 
   public override bool IsEscaping(IHierarchical target) {
@@ -21,25 +18,7 @@ public class SpeedEscapeDetector : EscapeDetectorBase {
 
   // Calculate the predicted agent speed when it has reached the target's current position.
   private float CalculatePredictedAgentSpeed(in Vector3 targetPosition) {
-    // The speed decays exponentially with the traveled distance and with the bearing change.
-    float distanceTimeConstant = 2 * (Agent.StaticConfig.BodyConfig?.Mass ?? 0) /
-                                 (Constants.CalculateAirDensityAtAltitude(Agent.Position.y) *
-                                  (Agent.StaticConfig.LiftDragConfig?.DragCoefficient ?? 0) *
-                                  (Agent.StaticConfig.BodyConfig?.CrossSectionalArea ?? 0));
-    float angleTimeConstant = Agent.StaticConfig.LiftDragConfig?.LiftDragRatio ?? 1;
-    // During the turn, the minimum radius dictates the minimum distance needed to make the turn.
-    float minTurningRadius = Agent.Velocity.sqrMagnitude / Agent.MaxNormalAcceleration();
-
-    Vector3 directionToTarget = targetPosition - Agent.Position;
-    float distanceToTarget = directionToTarget.magnitude;
-    float angleToTarget = Vector3.Angle(Agent.Velocity, directionToTarget) * Mathf.Deg2Rad;
-    // The fractional speed is the product of the fractional speed after traveling the distance and
-    // of the fractional speed after turning.
-    float fractionalSpeed =
-        Mathf.Exp(-((distanceToTarget + angleToTarget * minTurningRadius) / distanceTimeConstant +
-                    angleToTarget / angleTimeConstant));
-    // Prevent division by zero.
-    fractionalSpeed = Mathf.Max(fractionalSpeed, _minFractionalSpeed);
+    float fractionalSpeed = FractionalSpeed.Calculate(Agent, targetPosition);
     return fractionalSpeed * Agent.Speed;
   }
 }

--- a/Assets/Scripts/Hierarchical/HierarchicalBase.cs
+++ b/Assets/Scripts/Hierarchical/HierarchicalBase.cs
@@ -223,7 +223,7 @@ public class HierarchicalBase : IHierarchical {
     Func<IHierarchical, float> metric =
         hierarchical is HierarchicalAgent hierarchicalAgent? subHierarchical =>
             FractionalSpeed.Calculate(hierarchicalAgent.Agent, subHierarchical.Position)
-        : subHierarchical => Vector3.Distance(hierarchical.Position, subHierarchical.Position);
+        : subHierarchical => -Vector3.Distance(hierarchical.Position, subHierarchical.Position);
     var targetSubHierarchicals = assignments[0].Second.ActiveSubHierarchicals;
     var filteredSubHierarchicals = targetSubHierarchicals.OrderByDescending(metric).Take(capacity);
 

--- a/Assets/Scripts/Hierarchical/IHierarchical.cs
+++ b/Assets/Scripts/Hierarchical/IHierarchical.cs
@@ -41,7 +41,6 @@ public interface IHierarchical {
   // Recursively cluster the targets.
   void RecursiveCluster(int maxClusterSize);
 
-  // Assign a new target to the given hierarchical object. Return whether a new target was
-  // successfully assigned to the hierarchical object.
-  bool AssignNewTarget(IHierarchical hierarchical, int capacity);
+  // Find a new target for the given hierarchical object and return it if a possible target exists.
+  IHierarchical FindNewTarget(IHierarchical hierarchical, int capacity);
 }

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -58,11 +58,11 @@ public class IADS : MonoBehaviour {
     _newThreats.Clear();
   }
 
-  public void RegisterNewLauncher(IInterceptor interceptor) {
-    if (interceptor.HierarchicalAgent != null) {
-      interceptor.OnAssignSubInterceptor += AssignSubInterceptor;
-      interceptor.OnReassignTarget += ReassignTarget;
-      _launchers.Add(interceptor.HierarchicalAgent);
+  public void RegisterNewLauncher(IInterceptor launcher) {
+    if (launcher.HierarchicalAgent != null) {
+      launcher.OnAssignSubInterceptor += AssignSubInterceptor;
+      launcher.OnReassignTarget += ReassignTarget;
+      _launchers.Add(launcher.HierarchicalAgent);
     }
   }
 

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -120,8 +120,10 @@ public class IADS : MonoBehaviour {
             .OrderBy(launcher =>
                          Vector3.Distance(subInterceptor.Position, launcher.Target.Position));
     foreach (var launcher in sortedLaunchers) {
-      if (launcher.AssignNewTarget(subInterceptor.HierarchicalAgent,
-                                   subInterceptor.CapacityRemaining)) {
+      IHierarchical target = launcher.FindNewTarget(subInterceptor.HierarchicalAgent,
+                                                    subInterceptor.CapacityRemaining);
+      subInterceptor.EvaluateReassignedTarget(target);
+      if (target != null) {
         break;
       }
     }

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -122,8 +122,7 @@ public class IADS : MonoBehaviour {
     foreach (var launcher in sortedLaunchers) {
       IHierarchical target = launcher.FindNewTarget(subInterceptor.HierarchicalAgent,
                                                     subInterceptor.CapacityRemaining);
-      subInterceptor.EvaluateReassignedTarget(target);
-      if (target != null) {
+      if (subInterceptor.EvaluateReassignedTarget(target)) {
         break;
       }
     }

--- a/Assets/Scripts/Interceptors/IInterceptor.cs
+++ b/Assets/Scripts/Interceptors/IInterceptor.cs
@@ -45,6 +45,9 @@ public interface IInterceptor : IAgent {
   // Number of sub-interceptors remaining.
   int NumSubInterceptorsRemaining { get; }
 
+  // If true, the interceptor can be reassigned to other targets.
+  bool IsReassignable { get; }
+
   // Assign a new target to the sub-interceptor.
   void AssignSubInterceptor(IInterceptor subInterceptor);
 

--- a/Assets/Scripts/Interceptors/IInterceptor.cs
+++ b/Assets/Scripts/Interceptors/IInterceptor.cs
@@ -48,8 +48,9 @@ public interface IInterceptor : IAgent {
   // If true, the interceptor can be reassigned to other targets.
   bool IsReassignable { get; }
 
-  // Evaluate whether to be reassigned to the new target.
-  void EvaluateReassignedTarget(IHierarchical target);
+  // Evaluate whether to be reassigned to the new target. Return whether the new target was
+  // accepted.
+  bool EvaluateReassignedTarget(IHierarchical target);
 
   // Assign a new target to the sub-interceptor.
   void AssignSubInterceptor(IInterceptor subInterceptor);

--- a/Assets/Scripts/Interceptors/IInterceptor.cs
+++ b/Assets/Scripts/Interceptors/IInterceptor.cs
@@ -48,6 +48,9 @@ public interface IInterceptor : IAgent {
   // If true, the interceptor can be reassigned to other targets.
   bool IsReassignable { get; }
 
+  // Evaluate whether to be reassigned to the new target.
+  void EvaluateReassignedTarget(IHierarchical target);
+
   // Assign a new target to the sub-interceptor.
   void AssignSubInterceptor(IInterceptor subInterceptor);
 

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -76,14 +76,39 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   // Coroutine for handling unassigned targets.
   private Coroutine _unassignedTargetsCoroutine;
 
+  public void EvaluateReassignedTarget(IHierarchical target) {
+    // Continue searching for targets if no target was found.
+    if (target == null) {
+      return;
+    }
+
+    // If the interceptor has no target, always accept the new target.
+    if (HierarchicalAgent.Target == null || HierarchicalAgent.Target.IsTerminated) {
+      HierarchicalAgent.Target = target;
+      return;
+    }
+
+    // Accept the new target if the intercept speed is higher.
+    float currentFractionalSpeed =
+        FractionalSpeed.Calculate(this, HierarchicalAgent.Target.Position);
+    float newFractionalSpeed = FractionalSpeed.Calculate(this, target.Position);
+    if (newFractionalSpeed > currentFractionalSpeed) {
+      HierarchicalAgent.Target = target;
+    }
+  }
+
   public void AssignSubInterceptor(IInterceptor subInterceptor) {
     if (subInterceptor.CapacityRemaining <= 0) {
       return;
     }
 
-    // Assign a new target to the sub-interceptor within the parent interceptor's assigned targets.
-    if (!HierarchicalAgent.AssignNewTarget(subInterceptor.HierarchicalAgent,
-                                           subInterceptor.CapacityRemaining)) {
+    // Find a new target for the sub-interceptor within the parent interceptor's assigned targets.
+    IHierarchical target = HierarchicalAgent.FindNewTarget(subInterceptor.HierarchicalAgent,
+                                                           subInterceptor.CapacityRemaining);
+    if (target != null) {
+      // Evaluate the new target and decide whether to continue searching for other targets.
+      subInterceptor.EvaluateReassignedTarget(target);
+    } else {
       // Propagate the sub-interceptor target assignment to the parent interceptor above.
       OnAssignSubInterceptor?.Invoke(subInterceptor);
     }

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -117,7 +117,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     // Check whether the interceptor has a target. If not, request a new target from the parent
     // interceptor.
     if (HierarchicalAgent.Target == null || HierarchicalAgent.Target.IsTerminated) {
-      RequestReassignment();
+      RequestReassignment(this);
     }
 
     // Check whether any targets are escaping from the interceptor.
@@ -131,7 +131,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
         OnReassignTarget?.Invoke(target);
       }
       if (escapingTargets.Count == targetHierarchicals.Count) {
-        RequestReassignment();
+        RequestReassignment(this);
       }
     }
 
@@ -261,13 +261,13 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
       OnReassignTarget?.Invoke(targetHierarchical);
     }
 
-    RequestReassignment();
+    RequestReassignment(interceptor);
   }
 
-  private void RequestReassignment() {
-    if (IsReassignable) {
+  private void RequestReassignment(IInterceptor interceptor) {
+    if (interceptor.IsReassignable) {
       // Request a new target from the parent interceptor.
-      OnAssignSubInterceptor?.Invoke(this);
+      OnAssignSubInterceptor?.Invoke(interceptor);
     }
   }
 

--- a/Assets/Scripts/Interceptors/LauncherBase.cs
+++ b/Assets/Scripts/Interceptors/LauncherBase.cs
@@ -9,6 +9,9 @@ public abstract class LauncherBase : CarrierBase {
   // Launchers cannot pursue threats.
   public override bool IsPursuer => false;
 
+  // Launchers cannot be reassigned to other targets and rely on threat reassignment only.
+  public override bool IsReassignable => false;
+
   protected override void Awake() {
     base.Awake();
 

--- a/Assets/Scripts/Utils/FractionalSpeed.cs
+++ b/Assets/Scripts/Utils/FractionalSpeed.cs
@@ -9,7 +9,8 @@ public static class FractionalSpeed {
                                  (Constants.CalculateAirDensityAtAltitude(agent.Position.y) *
                                   (agent.StaticConfig.LiftDragConfig?.DragCoefficient ?? 0) *
                                   (agent.StaticConfig.BodyConfig?.CrossSectionalArea ?? 0));
-    float angleTimeConstant = agent.StaticConfig.LiftDragConfig?.LiftDragRatio ?? 1;
+    float angleTimeConstant =
+        agent.StaticConfig.LiftDragConfig?.LiftDragRatio ?? float.PositiveInfinity;
     // During the turn, the minimum radius dictates the minimum distance needed to make the turn.
     float minTurningRadius = agent.Velocity.sqrMagnitude / agent.MaxNormalAcceleration();
 

--- a/Assets/Scripts/Utils/FractionalSpeed.cs
+++ b/Assets/Scripts/Utils/FractionalSpeed.cs
@@ -5,7 +5,7 @@ public static class FractionalSpeed {
   // target position.
   public static float Calculate(IAgent agent, in Vector3 targetPosition) {
     // The speed decays exponentially with the traveled distance and with the bearing change.
-    float distanceTimeConstant = 2 * (agent.StaticConfig.BodyConfig?.Mass ?? 0) /
+    float distanceTimeConstant = 2 * (agent.StaticConfig.BodyConfig?.Mass ?? 1) /
                                  (Constants.CalculateAirDensityAtAltitude(agent.Position.y) *
                                   (agent.StaticConfig.LiftDragConfig?.DragCoefficient ?? 0) *
                                   (agent.StaticConfig.BodyConfig?.CrossSectionalArea ?? 0));

--- a/Assets/Scripts/Utils/FractionalSpeed.cs
+++ b/Assets/Scripts/Utils/FractionalSpeed.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+public static class FractionalSpeed {
+  // Calculate the estimated fractional speed for the given hierarchical object to reach the given
+  // target position.
+  public static float Calculate(IAgent agent, in Vector3 targetPosition) {
+    // The speed decays exponentially with the traveled distance and with the bearing change.
+    float distanceTimeConstant = 2 * (agent.StaticConfig.BodyConfig?.Mass ?? 0) /
+                                 (Constants.CalculateAirDensityAtAltitude(agent.Position.y) *
+                                  (agent.StaticConfig.LiftDragConfig?.DragCoefficient ?? 0) *
+                                  (agent.StaticConfig.BodyConfig?.CrossSectionalArea ?? 0));
+    float angleTimeConstant = agent.StaticConfig.LiftDragConfig?.LiftDragRatio ?? 1;
+    // During the turn, the minimum radius dictates the minimum distance needed to make the turn.
+    float minTurningRadius = agent.Velocity.sqrMagnitude / agent.MaxNormalAcceleration();
+
+    Vector3 directionToTarget = targetPosition - agent.Position;
+    float distanceToTarget = directionToTarget.magnitude;
+    float angleToTarget = Vector3.Angle(agent.Velocity, directionToTarget) * Mathf.Deg2Rad;
+    // The fractional speed is the product of the fractional speed after traveling the distance and
+    // of the fractional speed after turning.
+    float fractionalSpeed =
+        Mathf.Exp(-((distanceToTarget + angleToTarget * minTurningRadius) / distanceTimeConstant +
+                    angleToTarget / angleTimeConstant));
+    return fractionalSpeed;
+  }
+}

--- a/Assets/Scripts/Utils/FractionalSpeed.cs.meta
+++ b/Assets/Scripts/Utils/FractionalSpeed.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6d2f237510c434e948ebe525ea937f6c

--- a/Assets/Tests/EditMode/FractionalSpeedTests.cs
+++ b/Assets/Tests/EditMode/FractionalSpeedTests.cs
@@ -1,0 +1,71 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class FractionalSpeedTests : TestBase {
+  private AgentBase _agent;
+
+  [SetUp]
+  public void SetUp() {
+    _agent = new GameObject("Agent").AddComponent<AgentBase>();
+    _agent.gameObject.AddComponent<Rigidbody>();
+    InvokePrivateMethod(_agent, "Awake");
+    _agent.Velocity = new Vector3(0, 0, 1);
+    _agent.Transform.rotation = Quaternion.LookRotation(new Vector3(0, 0, 1));
+    // No maximum normal acceleration is specified, so it defaults to infinite normal acceleration,
+    // meaning the agent has a minimum turn radius of 0.
+    _agent.StaticConfig = new Configs.StaticConfig() {
+      LiftDragConfig =
+          new Configs.LiftDragConfig() {
+            DragCoefficient = 0.7f,
+            LiftDragRatio = 5,
+          },
+      BodyConfig =
+          new Configs.BodyConfig() {
+            CrossSectionalArea = 1,
+            Mass = 1,
+          },
+    };
+  }
+
+  [Test]
+  public void Calculate_DistanceOnly_ReturnsCorrectly() {
+    Vector3 targetPosition = new Vector3(0, 0, 5);
+    float distanceTimeConstant = 2 / (1.204f * 0.7f * 1);
+    float expectedFractionalSpeed = Mathf.Exp(-5 / distanceTimeConstant);
+    Assert.AreEqual(expectedFractionalSpeed, FractionalSpeed.Calculate(_agent, targetPosition));
+  }
+
+  [Test]
+  public void Calculate_DistanceAndBearing_ReturnsCorrectly() {
+    Vector3 targetPosition = new Vector3(0, 5, 0);
+    float distanceTimeConstant = 2 / (1.204f * 0.7f * 1);
+    float angleTimeConstant = 5f;
+    float expectedFractionalSpeed =
+        Mathf.Exp(-(5 / distanceTimeConstant + Mathf.PI / 2 / angleTimeConstant));
+    Assert.AreEqual(expectedFractionalSpeed, FractionalSpeed.Calculate(_agent, targetPosition));
+  }
+
+  [Test]
+  public void Calculate_DistanceOnly_MissingLiftDragConfig_ReturnsOne() {
+    _agent.StaticConfig.LiftDragConfig = null;
+    Vector3 targetPosition = new Vector3(0, 0, 5);
+    float expectedFractionalSpeed = 1f;
+    Assert.AreEqual(expectedFractionalSpeed, FractionalSpeed.Calculate(_agent, targetPosition));
+  }
+
+  [Test]
+  public void Calculate_DistanceOnly_MissingBodyConfig_ReturnsOne() {
+    _agent.StaticConfig.BodyConfig = null;
+    Vector3 targetPosition = new Vector3(0, 0, 5);
+    float expectedFractionalSpeed = 1f;
+    Assert.AreEqual(expectedFractionalSpeed, FractionalSpeed.Calculate(_agent, targetPosition));
+  }
+
+  [Test]
+  public void Calculate_DistanceAndBearing_MissingLiftDragConfig_ReturnsOne() {
+    _agent.StaticConfig.LiftDragConfig = null;
+    Vector3 targetPosition = new Vector3(0, 5, 0);
+    float expectedFractionalSpeed = 1f;
+    Assert.AreEqual(expectedFractionalSpeed, FractionalSpeed.Calculate(_agent, targetPosition));
+  }
+}

--- a/Assets/Tests/EditMode/FractionalSpeedTests.cs.meta
+++ b/Assets/Tests/EditMode/FractionalSpeedTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6f327e73d2ff94e4fa3c26599a4b0eaa


### PR DESCRIPTION
This PR resolves #197.  The problem with the previous interceptor reassignment occurs when a missile interceptor with capacity 1 is reassigned to a new threat that is selected from a leaf hierarchical's target cluster.  Previously, this selection was based on the distance from the threat's position to the cluster's centroid (so all interceptors were assigned to the same threat).  This PR changes this selection process to optimize for the intercept speed.

To clean up the code, calculating the fractional speed was refactored into its standalone static class `FractionalSpeed`.  Furthermore, I modified the `AssignNewTarget` method to `FindNewTarget` to return a candidate threat.  Each interceptor will then decide whether to accept the new threat or not in the `EvaluateReassignedTarget` method.

In this screenshot, you can see that most interceptors are reassigned to the next swarm of threats instead of forced to turn around to deal with the single missed threat from the first swarm.  The reassigned targets are also spread out depending on the interceptor locations.

<img width="962" height="564" alt="image" src="https://github.com/user-attachments/assets/51fd4160-5945-4133-962b-0389b8ee5b20" />

cc: @Joseph0120