### PR TITLE
[Logging] Check for null agents using MonoBehaviour

### DIFF
--- a/Assets/Scripts/Monitors/SimMonitor.cs
+++ b/Assets/Scripts/Monitors/SimMonitor.cs
@@ -201,17 +201,16 @@ public class SimMonitor : MonoBehaviour {
   }
 
   private void RecordTelemetry() {
-    float time = SimManager.Instance.ElapsedTime;
-    List<IAgent> agents = SimManager.Instance.Agents.Where(agent => !agent.IsTerminated).ToList();
     if (_telemetryBinaryWriter == null) {
       Debug.LogWarning("Telemetry binary writer is null.");
       return;
     }
-    foreach (var agent in agents) {
-      if (!agent.gameObject.activeInHierarchy) {
-        continue;
-      }
 
+    float time = SimManager.Instance.ElapsedTime;
+    var agents = SimManager.Instance.Agents.Where(agent => (agent as AgentBase) != null &&
+                                                           !agent.IsTerminated &&
+                                                           agent.gameObject.activeInHierarchy);
+    foreach (var agent in agents) {
       Vector3 position = agent.Position;
       if (position == Vector3.zero) {
         continue;

--- a/Assets/Scripts/Monitors/SimMonitor.cs
+++ b/Assets/Scripts/Monitors/SimMonitor.cs
@@ -207,9 +207,8 @@ public class SimMonitor : MonoBehaviour {
     }
 
     float time = SimManager.Instance.ElapsedTime;
-    var agents = SimManager.Instance.Agents.Where(agent => (agent as AgentBase) != null &&
-                                                           !agent.IsTerminated &&
-                                                           agent.gameObject.activeInHierarchy);
+    var agents = SimManager.Instance.Agents.OfType<AgentBase>().Where(
+        agent => agent != null && !agent.IsTerminated && agent.gameObject.activeInHierarchy);
     foreach (var agent in agents) {
       Vector3 position = agent.Position;
       if (position == Vector3.zero) {


### PR DESCRIPTION
Resolves #203.  During the simulation destruction, agents might already be destroyed, but the `SimMonitor` still wants to log one last telemetry data point for them.  `IAgent` is an interface independent of `MonoBehaviour`, so the null check does not return correctly for fake-null objects.  Instead, the agent has to be cast to `AgentBase`, which will then invoke the fake-null-compatible comparison with `null`.