### PR TITLE
[Communication] Created base Messaging Envelopes

### DIFF
--- a/Assets/Scripts/Agents/Messaging/IMessagePayload.cs
+++ b/Assets/Scripts/Agents/Messaging/IMessagePayload.cs
@@ -1,0 +1,3 @@
+// Interface for MessagePayload
+
+public interface IMessagePayload {}

--- a/Assets/Scripts/Agents/Messaging/LatencyTable.cs
+++ b/Assets/Scripts/Agents/Messaging/LatencyTable.cs
@@ -1,0 +1,36 @@
+using System;
+using UnityEngine;
+
+
+// Latency Table keeps track of the delay between every agent.
+// Table is n * n sized, n is the size of CommsNode.
+
+public enum CommsNode {
+    IADS = 0,
+    Carrier = 1,
+    Interceptor = 2,
+}
+
+// Setting everything to 0 should behave like with no latency
+public sealed class LatencyTable {
+    private readonly float[,] _latency;
+
+    // creates empty _latency array with defaultSeconds seconds each
+    public LatencyTable(float defaultSeconds = 0f) {
+        int n = Enum.GetValues(typeof(CommsNode)).Length;
+        _latency = new float[n, n];
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                _latency[i, j] = defaultSeconds;
+            }
+        }
+    }
+
+    public void Set(CommsNode from, CommsNode to, float seconds) {
+        _latency[(int) from, (int) to] = Mathf.Max(0f, seconds);
+    }
+
+    public float Get(CommsNode from, CommsNode to) {
+        return _latency[(int) from, (int) to];
+    }
+}

--- a/Assets/Scripts/Agents/Messaging/Message.cs
+++ b/Assets/Scripts/Agents/Messaging/Message.cs
@@ -1,0 +1,56 @@
+using System;
+
+/* Message is a base envolope for message sending. It always carries Sender, Reciever, Type, and Payload.
+This file wraps the payload data with transport metadata. It interntionally layers and splits the
+payload and the transportation data. Mailbox only focuses on transportation (enqueue, latency,
+and delivery timing) */
+
+// Types of Message types based on inter-agent communication contents.
+
+public enum MessageType {
+  AssignSubInterceptorRequest,
+  AssignTarget,
+  ReassignTargetRequest,
+}
+
+// Base envelope for agent to agent messages.
+public abstract class Message {
+  public IAgent Sender { get; }
+  public IAgent Receiver { get; }
+  public MessageType Type { get; }
+
+  public abstract IMessagePayload Payload { get; }
+
+  protected Message(IAgent sender, IAgent receiver, MessageType type) {
+    Sender = sender ?? throw new ArgumentNullException(nameof(sender));
+    Receiver = receiver ?? throw new ArgumentNullException(nameof(receiver));
+    Type = type;
+  }
+}
+
+public sealed class AssignSubInterceptorRequestMessage : Message {
+  public AssignSubInterceptorRequestPayload PayloadData { get; }
+  public override IMessagePayload Payload => PayloadData;
+
+  public AssignSubInterceptorRequestMessage(IAgent sender, IAgent receiver, IInterceptor subInterceptor) : base(sender, receiver, MessageType.AssignSubInterceptorRequest) {
+    PayloadData = new AssignSubInterceptorRequestPayload(subInterceptor);
+  }
+}
+
+public sealed class AssignTargetMessage : Message {
+  public AssignTargetPayload PayloadData { get; }
+  public override IMessagePayload Payload => PayloadData;
+
+  public AssignTargetMessage(IAgent sender, IAgent receiver, IHierarchical target) : base(sender, receiver, MessageType.AssignTarget) {
+    PayloadData = new AssignTargetPayload(target);
+  }
+}
+
+public sealed class ReassignTargetRequestMessage : Message {
+  public ReassignTargetRequestPayload PayloadData { get; }
+  public override IMessagePayload Payload => PayloadData;
+
+  public ReassignTargetRequestMessage(IAgent sender, IAgent receiver, IHierarchical target) : base(sender, receiver, MessageType.ReassignTargetRequest) {
+    PayloadData = new ReassignTargetRequestPayload(target);
+  }
+}

--- a/Assets/Scripts/Agents/Messaging/MessagePayload.cs
+++ b/Assets/Scripts/Agents/Messaging/MessagePayload.cs
@@ -1,0 +1,29 @@
+using System;
+
+/* MessagePayload defines different types of new payload objects. Payload is carried by 
+Message envolopes. Concrete payload content lives in here and are only read explicitly 
+by receivers. */
+
+public sealed class AssignSubInterceptorRequestPayload : IMessagePayload {
+  public IInterceptor SubInterceptor { get; }
+
+  public AssignSubInterceptorRequestPayload(IInterceptor subInterceptor) {
+    SubInterceptor = subInterceptor ?? throw new ArgumentNullException(nameof(subInterceptor));
+  }
+}
+
+public sealed class AssignTargetPayload : IMessagePayload {
+  public IHierarchical Target { get; }
+
+  public AssignTargetPayload(IHierarchical target) {
+    Target = target ?? throw new ArgumentNullException(nameof(target));
+  }
+}
+
+public sealed class ReassignTargetRequestPayload : IMessagePayload {
+  public IHierarchical Target { get; }
+
+  public ReassignTargetRequestPayload(IHierarchical target) {
+    Target = target ?? throw new ArgumentNullException(nameof(target));
+  }
+}

--- a/Assets/Scripts/Agents/Messaging/PendingMessage.cs
+++ b/Assets/Scripts/Agents/Messaging/PendingMessage.cs
@@ -1,0 +1,18 @@
+using System;
+
+/* This is the mailbox's internaal queue item. It stores the Message object 
+and DeliverAt into the priority queue and pops the message when DeliverAt
+time has reached. */
+
+public readonly struct PendingMessage {
+    public float DeliverAt { get; }
+    public Message Message { get; }
+
+    public IAgent Sender => Message?.Sender;
+    public IAgent Receiver => Message?.Receiver;
+
+    public PendingMessage(float deliverAt, Message message) {
+        DeliverAt = deliverAt;
+        Message = message ?? throw new ArgumentNullException(nameof(message));
+    }
+}


### PR DESCRIPTION
Added Files:
IMessagePayload.cs
LatencyTable.cs
Message.cs
MessagePayload.cs
PendingMessage.cs


Descriptions
IMessagePayload.cs is the Interface for MessagePayload.

LatencyTable.cs creates a table that keeps track of the delay between every agent.

Message.cs creates a base envolope for message sending. It always carries Sender, Reciever, Type, and Payload.
This file wraps the payload data with transport metadata. It interntionally layers and splits the
payload and the transportation data. Mailbox only focuses on transportation (enqueue, latency,
and delivery timing)

MessagePayload.cs defines different types of new payload objects. Payload is carried by 
Message envolopes. Concrete payload content lives in here and are only read explicitly 
by receivers.

PendingMessage.cs is the mailbox's internaal queue item. It stores the Message object 
and DeliverAt into the priority queue and pops the message when DeliverAt
time has reached.