### PR TITLE
[Communication] PR6: InterceptorBase.cs now supports mailbox.

### DIFF
--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -121,6 +121,9 @@ public class IADS : MonoBehaviour {
   }
 
   public void RegisterNewAsset(IInterceptor asset) {
+    if (asset is InterceptorBase interceptorBase) {
+      interceptorBase.CommsParent = _commsAgent;
+    }
     if (asset?.HierarchicalAgent == null || asset.IsPursuer ||
         _assets.Contains(asset.HierarchicalAgent)) {
       return;

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -121,14 +121,14 @@ public class IADS : MonoBehaviour {
   }
 
   public void RegisterNewAsset(IInterceptor asset) {
-    if (asset is InterceptorBase interceptorBase) {
-      interceptorBase.CommsParent = _commsAgent;
-    }
     if (asset?.HierarchicalAgent == null || asset.IsPursuer ||
         _assets.Contains(asset.HierarchicalAgent)) {
       return;
     }
 
+    if (asset is InterceptorBase interceptorBase) {
+      interceptorBase.CommsParent = _commsAgent;
+    }
     _assets.Add(asset.HierarchicalAgent);
   }
 

--- a/Assets/Scripts/Interceptors/CarrierBase.cs
+++ b/Assets/Scripts/Interceptors/CarrierBase.cs
@@ -48,6 +48,9 @@ public abstract class CarrierBase : InterceptorBase {
           if (agent is IInterceptor subInterceptor) {
             subInterceptor.OnAssignSubInterceptor += AssignSubInterceptor;
             subInterceptor.OnReassignTarget += ReassignTarget;
+            if (subInterceptor is InterceptorBase interceptorBase) {
+              interceptorBase.CommsParent = this;
+            }
             if (subInterceptor.Movement is MissileMovement movement) {
               movement.FlightPhase = Simulation.FlightPhase.Boost;
             }

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -118,11 +118,6 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     } else {
       SendAssignRequestToParent(subInterceptor);
     }
-    // Evaluate the new target and decide whether to continue searching for other targets.
-    if (!subInterceptor.EvaluateReassignedTarget(target)) {
-      // Propagate the sub-interceptor target assignment to the parent interceptor above.
-      SendReassignRequestToParent(target);
-    }
   }
 
   public void ReassignTarget(IHierarchical target) {

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -5,11 +5,10 @@ using UnityEngine;
 
 // Base implementation of an interceptor.
 public abstract class InterceptorBase : AgentBase, IInterceptor {
-
   // Sets Mailbox NodeType to "Interceptor"
   public override CommsNode NodeType => CommsNode.Interceptor;
 
-  //CommsParent establishes Parent – Child relationship. Provides quick parent lookup.
+  // CommsParent establishes Parent – Child relationship. Provides quick parent lookup.
   public IAgent CommsParent { get; set; }
 
   public event InterceptorEventHandler OnHit;
@@ -108,7 +107,9 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   }
 
   public void AssignSubInterceptor(IInterceptor subInterceptor) {
-    if (subInterceptor == null || subInterceptor.Capacity <= 0) { return; }
+    if (subInterceptor == null || subInterceptor.Capacity <= 0) {
+      return;
+    }
 
     // Find a new target for the sub-interceptor within the parent interceptor's assigned targets.
     IHierarchical target = HierarchicalAgent.FindNewTarget(subInterceptor.HierarchicalAgent,
@@ -284,7 +285,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     RequestTargetReassignment(interceptor);
 
     // Request a new target from the parent interceptor.
-    SendAssignRequestToParent(interceptor);;
+    SendAssignRequestToParent(interceptor);
   }
 
   private void RegisterDestroyed(IInterceptor interceptor) {
@@ -310,7 +311,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   private void RequestReassignment(IInterceptor interceptor) {
     if (interceptor.IsReassignable) {
       // Request a new target from the parent interceptor.
-      SendAssignRequestToParent(interceptor);;
+      SendAssignRequestToParent(interceptor);
     }
   }
 
@@ -371,32 +372,42 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   // AssignSubInterceptorRequest to parent.
   private void SendAssignRequestToParent(IInterceptor subInterceptor) {
     IAgent parent = CommsParent;
-    if (parent == null || subInterceptor == null) { return; }
+    if (parent == null || subInterceptor == null) {
+      return;
+    }
     SendMessage(new AssignSubInterceptorRequestMessage(this, parent, subInterceptor));
   }
 
   // ReassignTargetRequest to parent.
   private void SendReassignRequestToParent(IHierarchical target) {
     IAgent parent = CommsParent;
-    if (parent == null || target == null) { return; }
+    if (parent == null || target == null) {
+      return;
+    }
     SendMessage(new ReassignTargetRequestMessage(this, parent, target));
   }
 
   // SendAssignTarget to child.
   private void SendAssignTargetToSub(IInterceptor subInterceptor, IHierarchical target) {
-    if (subInterceptor == null || target == null) { return; }
+    if (subInterceptor == null || target == null) {
+      return;
+    }
     SendMessage(new AssignTargetMessage(this, subInterceptor, target));
   }
 
   // Send into Mailbox.
   private void SendMessage(Message message) {
-    if (message == null) { return; }
+    if (message == null) {
+      return;
+    }
     Mailbox mailbox = Mailbox.GetOrCreateInstance();
-    if (mailbox == null) { return; }
+    if (mailbox == null) {
+      return;
+    }
     mailbox.Send(message);
   }
 
-  // Execution happens here after recieving and reading message. PayloadData is read and handled.
+  // Execution happens here after receiving and reading message. PayloadData is read and handled.
   protected override void OnMessage(Message message) {
     if (message == null) {
       return;
@@ -409,12 +420,13 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
         ReassignTarget(reassignRequest.PayloadData.Target);
         break;
       case AssignTargetMessage assignTarget:
-        EvaluateReassignedTarget(assignTarget.PayloadData.Target);
-        // EvaluateReassignedTarget. If it is false then bounce back: send a RequestReassignment upwards.
-        if (!EvaluateReassignedTarget(assignTarget.PayloadData.Target)) {
+        bool accepted = EvaluateReassignedTarget(assignTarget.PayloadData.Target);
+        // EvaluateReassignedTarget. If it is false then bounce back: send a RequestReassignment
+        // upwards.
+        if (!accepted) {
           RequestReassignment(this);
         }
         break;
     }
-  }        
+  }
 }

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -428,7 +428,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
       case AssignTargetResponseMessage assignTarget:
         IHierarchical assignedTarget = assignTarget.PayloadData.Target;
         if (assignedTarget != null) {
-          HierarchicalAgent.Target = assignedTarget;
+          EvaluateReassignedTarget(assignedTarget);
         }
         break;
     }

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -5,10 +5,8 @@ using UnityEngine;
 
 // Base implementation of an interceptor.
 public abstract class InterceptorBase : AgentBase, IInterceptor {
-  // Sets Mailbox NodeType to "Interceptor"
-  public override CommsNode NodeType => CommsNode.Interceptor;
-
-  // CommsParent establishes Parent – Child relationship. Provides quick parent lookup.
+  // Optional mailbox receiver used to route requests to the logical parent interceptor or IADS
+  // proxy.
   public IAgent CommsParent { get; set; }
 
   public event InterceptorEventHandler OnHit;
@@ -302,7 +300,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     List<IHierarchical> targetHierarchicals =
         target.LeafHierarchicals(activeOnly: true, withTargetOnly: false);
     foreach (var targetHierarchical in targetHierarchicals) {
-      OnReassignTarget?.Invoke(targetHierarchical);
+      SendReassignRequestToParent(targetHierarchical);
     }
 
     RequestReassignment(interceptor);
@@ -372,19 +370,27 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   // AssignSubInterceptorRequest to parent.
   private void SendAssignRequestToParent(IInterceptor subInterceptor) {
     IAgent parent = CommsParent;
-    if (parent == null || subInterceptor == null) {
+    if (subInterceptor == null) {
       return;
     }
-    SendMessage(new AssignSubInterceptorRequestMessage(this, parent, subInterceptor));
+    if (parent == null) {
+      OnAssignSubInterceptor?.Invoke(subInterceptor);
+      return;
+    }
+    SendMailboxMessage(new AssignSubInterceptorRequestMessage(this, parent, subInterceptor));
   }
 
   // ReassignTargetRequest to parent.
   private void SendReassignRequestToParent(IHierarchical target) {
     IAgent parent = CommsParent;
-    if (parent == null || target == null) {
+    if (target == null) {
       return;
     }
-    SendMessage(new ReassignTargetRequestMessage(this, parent, target));
+    if (parent == null) {
+      OnReassignTarget?.Invoke(target);
+      return;
+    }
+    SendMailboxMessage(new ReassignTargetRequestMessage(this, parent, target));
   }
 
   // SendAssignTarget to child.
@@ -392,11 +398,11 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     if (subInterceptor == null || target == null) {
       return;
     }
-    SendMessage(new AssignTargetMessage(this, subInterceptor, target));
+    SendMailboxMessage(new AssignTargetMessage(this, subInterceptor, target));
   }
 
   // Send into Mailbox.
-  private void SendMessage(Message message) {
+  private void SendMailboxMessage(Message message) {
     if (message == null) {
       return;
     }
@@ -420,11 +426,9 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
         ReassignTarget(reassignRequest.PayloadData.Target);
         break;
       case AssignTargetMessage assignTarget:
-        bool accepted = EvaluateReassignedTarget(assignTarget.PayloadData.Target);
-        // EvaluateReassignedTarget. If it is false then bounce back: send a RequestReassignment
-        // upwards.
-        if (!accepted) {
-          RequestReassignment(this);
+        IHierarchical assignedTarget = assignTarget.PayloadData.Target;
+        if (assignedTarget != null) {
+          HierarchicalAgent.Target = assignedTarget;
         }
         break;
     }

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -415,6 +415,10 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
         break;
       case AssignTargetMessage assignTarget:
         EvaluateReassignedTarget(assignTarget.PayloadData.Target);
+        // EvaluateReassignedTarget. If it is false then bounce back: send a RequestReassignment upwards.
+        if (!EvaluateReassignedTarget(assignTarget.PayloadData.Target)) {
+          RequestReassignment(this);
+        }
         break;
     }
   }        

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -5,6 +5,13 @@ using UnityEngine;
 
 // Base implementation of an interceptor.
 public abstract class InterceptorBase : AgentBase, IInterceptor {
+
+  // Sets Mailbox NodeType to "Interceptor"
+  public override CommsNode NodeType => CommsNode.Interceptor;
+
+  //CommsParent establishes Parent – Child relationship. Provides quick parent lookup.
+  public IAgent CommsParent { get; set; }
+
   public event InterceptorEventHandler OnHit;
   public event InterceptorEventHandler OnMiss;
   public event InterceptorEventHandler OnDestroyed;
@@ -101,17 +108,20 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   }
 
   public void AssignSubInterceptor(IInterceptor subInterceptor) {
-    if (subInterceptor.CapacityRemaining <= 0) {
-      return;
-    }
+    if (subInterceptor == null || subInterceptor.Capacity <= 0) { return; }
 
     // Find a new target for the sub-interceptor within the parent interceptor's assigned targets.
     IHierarchical target = HierarchicalAgent.FindNewTarget(subInterceptor.HierarchicalAgent,
                                                            subInterceptor.CapacityRemaining);
+    if (target != null) {
+      SendAssignTargetToSub(subInterceptor, target);
+    } else {
+      SendAssignRequestToParent(subInterceptor);
+    }
     // Evaluate the new target and decide whether to continue searching for other targets.
     if (!subInterceptor.EvaluateReassignedTarget(target)) {
       // Propagate the sub-interceptor target assignment to the parent interceptor above.
-      OnAssignSubInterceptor?.Invoke(subInterceptor);
+      SendReassignRequestToParent(target);
     }
   }
 
@@ -123,7 +133,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     //  another sub-interceptor(s) to pursue the target(s).
     //  3. Propagate the target re-assignment to the parent interceptor above.
     if (CapacityPlannedRemaining <= 0) {
-      OnReassignTarget?.Invoke(target);
+      SendReassignRequestToParent(target);
       return;
     }
 
@@ -155,7 +165,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
       List<IHierarchical> escapingTargets =
           targetHierarchicals.Where(EscapeDetector.IsEscaping).ToList();
       foreach (var target in escapingTargets) {
-        OnReassignTarget?.Invoke(target);
+        SendReassignRequestToParent(target);
       }
       if (escapingTargets.Count == targetHierarchicals.Count) {
         RequestReassignment(this);
@@ -279,7 +289,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     RequestTargetReassignment(interceptor);
 
     // Request a new target from the parent interceptor.
-    OnAssignSubInterceptor?.Invoke(interceptor);
+    SendAssignRequestToParent(interceptor);;
   }
 
   private void RegisterDestroyed(IInterceptor interceptor) {
@@ -305,7 +315,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   private void RequestReassignment(IInterceptor interceptor) {
     if (interceptor.IsReassignable) {
       // Request a new target from the parent interceptor.
-      OnAssignSubInterceptor?.Invoke(interceptor);
+      SendAssignRequestToParent(interceptor);;
     }
   }
 
@@ -335,7 +345,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
             filteredTargets.OrderBy(target => Vector3.Distance(Position, target.Position));
         var excessTargets = orderedTargets.Skip(CapacityPlannedRemaining);
         foreach (var target in excessTargets) {
-          OnReassignTarget?.Invoke(target);
+          SendReassignRequestToParent(target);
         }
         unassignedTargets = orderedTargets.Take(CapacityPlannedRemaining);
       } else {
@@ -362,4 +372,50 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
       newSubHierarchical.RecursiveCluster(maxClusterSize: CapacityPerSubInterceptor);
     }
   }
+
+  // AssignSubInterceptorRequest to parent.
+  private void SendAssignRequestToParent(IInterceptor subInterceptor) {
+    IAgent parent = CommsParent;
+    if (parent == null || subInterceptor == null) { return; }
+    SendMessage(new AssignSubInterceptorRequestMessage(this, parent, subInterceptor));
+  }
+
+  // ReassignTargetRequest to parent.
+  private void SendReassignRequestToParent(IHierarchical target) {
+    IAgent parent = CommsParent;
+    if (parent == null || target == null) { return; }
+    SendMessage(new ReassignTargetRequestMessage(this, parent, target));
+  }
+
+  // SendAssignTarget to child.
+  private void SendAssignTargetToSub(IInterceptor subInterceptor, IHierarchical target) {
+    if (subInterceptor == null || target == null) { return; }
+    SendMessage(new AssignTargetMessage(this, subInterceptor, target));
+  }
+
+  // Send into Mailbox.
+  private void SendMessage(Message message) {
+    if (message == null) { return; }
+    Mailbox mailbox = Mailbox.GetOrCreateInstance();
+    if (mailbox == null) { return; }
+    mailbox.Send(message);
+  }
+
+  // Execution happens here after recieving and reading message. PayloadData is read and handled.
+  protected override void OnMessage(Message message) {
+    if (message == null) {
+      return;
+    }
+    switch (message) {
+      case AssignSubInterceptorRequestMessage assignRequest:
+        AssignSubInterceptor(assignRequest.PayloadData.SubInterceptor);
+        break;
+      case ReassignTargetRequestMessage reassignRequest:
+        ReassignTarget(reassignRequest.PayloadData.Target);
+        break;
+      case AssignTargetMessage assignTarget:
+        EvaluateReassignedTarget(assignTarget.PayloadData.Target);
+        break;
+    }
+  }        
 }

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -105,7 +105,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   }
 
   public void AssignSubInterceptor(IInterceptor subInterceptor) {
-    if (subInterceptor == null || subInterceptor.Capacity <= 0) {
+    if (subInterceptor == null || subInterceptor.CapacityRemaining <= 0) {
       return;
     }
 
@@ -367,7 +367,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     }
   }
 
-  // AssignSubInterceptorRequest to parent.
+  // Send an AssignTargetRequest message to the parent mailbox receiver.
   private void SendAssignRequestToParent(IInterceptor subInterceptor) {
     IAgent parent = CommsParent;
     if (subInterceptor == null) {
@@ -377,10 +377,10 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
       OnAssignSubInterceptor?.Invoke(subInterceptor);
       return;
     }
-    SendMailboxMessage(new AssignSubInterceptorRequestMessage(this, parent, subInterceptor));
+    SendMailboxMessage(new AssignTargetRequestMessage(this, parent, subInterceptor));
   }
 
-  // ReassignTargetRequest to parent.
+  // Send a ReassignTargetRequest message to the parent mailbox receiver.
   private void SendReassignRequestToParent(IHierarchical target) {
     IAgent parent = CommsParent;
     if (target == null) {
@@ -393,15 +393,15 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     SendMailboxMessage(new ReassignTargetRequestMessage(this, parent, target));
   }
 
-  // SendAssignTarget to child.
+  // Send an AssignTargetResponse message to the child mailbox receiver.
   private void SendAssignTargetToSub(IInterceptor subInterceptor, IHierarchical target) {
     if (subInterceptor == null || target == null) {
       return;
     }
-    SendMailboxMessage(new AssignTargetMessage(this, subInterceptor, target));
+    SendMailboxMessage(new AssignTargetResponseMessage(this, subInterceptor, target));
   }
 
-  // Send into Mailbox.
+  // Send a message through the mailbox.
   private void SendMailboxMessage(Message message) {
     if (message == null) {
       return;
@@ -419,13 +419,13 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
       return;
     }
     switch (message) {
-      case AssignSubInterceptorRequestMessage assignRequest:
+      case AssignTargetRequestMessage assignRequest:
         AssignSubInterceptor(assignRequest.PayloadData.SubInterceptor);
         break;
       case ReassignTargetRequestMessage reassignRequest:
         ReassignTarget(reassignRequest.PayloadData.Target);
         break;
-      case AssignTargetMessage assignTarget:
+      case AssignTargetResponseMessage assignTarget:
         IHierarchical assignedTarget = assignTarget.PayloadData.Target;
         if (assignedTarget != null) {
           HierarchicalAgent.Target = assignedTarget;

--- a/Assets/Tests/EditMode/CarrierBaseMailboxTests.cs.meta
+++ b/Assets/Tests/EditMode/CarrierBaseMailboxTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2bcb7fd2c8997460788772dad50fdac3

--- a/Assets/Tests/EditMode/CarrierBaseMailboxTests.cs.meta
+++ b/Assets/Tests/EditMode/CarrierBaseMailboxTests.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 2bcb7fd2c8997460788772dad50fdac3

--- a/Assets/Tests/EditMode/IADSMailboxTests.cs
+++ b/Assets/Tests/EditMode/IADSMailboxTests.cs
@@ -174,6 +174,24 @@ public class IADSMailboxTests : TestBase {
     Assert.IsNull(deliveredResponse);
   }
 
+  // Verifies that top-level launchers route mailbox requests to the IADS proxy.
+  [Test]
+  public void RegisterNewLauncher_SetsCommsParentToIadsProxy() {
+    var launcherObject = new GameObject("Launcher");
+    try {
+      var launcher = launcherObject.AddComponent<TestLauncherInterceptor>();
+      launcherObject.AddComponent<Rigidbody>();
+      launcher.HierarchicalAgent = new HierarchicalAgent(launcher);
+      launcher.InvokeAwakeForTest();
+
+      _iads.RegisterNewLauncher(launcher);
+
+      Assert.AreSame(_commsAgent, launcher.CommsParent);
+    } finally {
+      Object.DestroyImmediate(launcherObject);
+    }
+  }
+
   private static SimManager CreateSimManagerStub() {
     return (SimManager)FormatterServices.GetUninitializedObject(typeof(SimManager));
   }
@@ -332,5 +350,17 @@ public class IADSMailboxTests : TestBase {
     public Transformation GetRelativeTransformation(IAgent target) => default;
     public Transformation GetRelativeTransformation(IHierarchical target) => default;
     public Transformation GetRelativeTransformation(in Vector3 waypoint) => default;
+  }
+
+  private sealed class TestLauncherInterceptor : InterceptorBase, IAgent {
+    public void InvokeAwakeForTest() {
+      base.Awake();
+    }
+
+    void IAgent.CreateTargetModel(IHierarchical target) {}
+
+    void IAgent.DestroyTargetModel() {}
+
+    void IAgent.UpdateTargetModel() {}
   }
 }

--- a/Assets/Tests/EditMode/IADSMailboxTests.cs
+++ b/Assets/Tests/EditMode/IADSMailboxTests.cs
@@ -353,6 +353,8 @@ public class IADSMailboxTests : TestBase {
   }
 
   private sealed class TestLauncherInterceptor : InterceptorBase, IAgent {
+    public override bool IsPursuer => false;
+
     public void InvokeAwakeForTest() {
       base.Awake();
     }

--- a/Assets/Tests/EditMode/IADSMailboxTests.cs.meta
+++ b/Assets/Tests/EditMode/IADSMailboxTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 21e3b19c559d14154a7b6884582418ab

--- a/Assets/Tests/EditMode/InterceptorBaseMailboxTests.cs
+++ b/Assets/Tests/EditMode/InterceptorBaseMailboxTests.cs
@@ -1,0 +1,294 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using UnityEngine;
+
+public class InterceptorBaseMailboxTests : TestBase {
+  private Mailbox _mailbox;
+  private SimManager _simManager;
+  private TestInterceptor _interceptor;
+
+  [SetUp]
+  public void SetUp() {
+    SetMailboxInstance(null);
+    SetSimManagerInstance(null);
+
+    _simManager = CreateSimManagerStub();
+    SetPrivateField(_simManager, "_dummyAgents", new List<IAgent>());
+    SetSimManagerInstance(_simManager);
+    SetElapsedTime(0f);
+
+    _mailbox = new GameObject("Mailbox").AddComponent<Mailbox>();
+
+    _interceptor = new GameObject("Interceptor").AddComponent<TestInterceptor>();
+    _interceptor.gameObject.AddComponent<Rigidbody>();
+    _interceptor.HierarchicalAgent = new HierarchicalAgent(_interceptor);
+    _interceptor.InvokeAwakeForTest();
+    _interceptor.StaticConfig = CreateStaticConfig(Configs.AgentType.CarrierInterceptor);
+  }
+
+  [TearDown]
+  public void TearDown() {
+    if (_interceptor?.TargetModel != null) {
+      _interceptor.DestroyTargetModel();
+    }
+    if (_interceptor != null) {
+      Object.DestroyImmediate(_interceptor.gameObject);
+    }
+    if (_mailbox != null) {
+      Object.DestroyImmediate(_mailbox.gameObject);
+    }
+    SetMailboxInstance(null);
+    SetSimManagerInstance(null);
+  }
+
+  // Verifies that a mailbox-delivered AssignTarget message updates the interceptor target.
+  [Test]
+  public void MailboxDelivery_AssignTargetMessage_AssignsHierarchicalTarget() {
+    var target = new FixedHierarchical(position: new Vector3(10f, 0f, 0f));
+    var message =
+        new AssignTargetMessage(new StubAgent(Configs.AgentType.Vessel), _interceptor, target);
+
+    _mailbox.Configure(null);
+    _mailbox.Send(message);
+
+    InvokePrivateMethod(_mailbox, "Update");
+
+    Assert.AreSame(target, _interceptor.HierarchicalAgent.Target);
+  }
+
+  // Verifies that a mailbox-delivered reassignment request is queued for later clustering.
+  [Test]
+  public void MailboxDelivery_ReassignTargetRequest_QueuesUnassignedTarget() {
+    SetPrivateField(_interceptor, "_capacityPerSubInterceptor", 1);
+    SetPrivateField(_interceptor, "_numSubInterceptorsPlannedRemaining", 1);
+
+    var target = new FixedHierarchical(position: new Vector3(5f, 0f, 0f));
+    var message = new ReassignTargetRequestMessage(new StubAgent(Configs.AgentType.Vessel),
+                                                   _interceptor, target);
+
+    _mailbox.Configure(null);
+    _mailbox.Send(message);
+
+    InvokePrivateMethod(_mailbox, "Update");
+
+    var queuedTargets = GetPrivateField<HashSet<IHierarchical>>(_interceptor, "_unassignedTargets");
+    Assert.True(queuedTargets.Contains(target));
+  }
+
+  // Verifies that a sub-interceptor assignment request is sent through the mailbox to the parent
+  // receiver when no target is currently available.
+  [Test]
+  public void AssignSubInterceptor_WithoutTarget_SendsAssignRequestToParentMailboxReceiver() {
+    var parent = new StubAgent(Configs.AgentType.Vessel);
+    _interceptor.CommsParent = parent;
+
+    var subInterceptor = new StubInterceptor(Configs.AgentType.MissileInterceptor, capacity: 1);
+    subInterceptor.HierarchicalAgent = new HierarchicalAgent(subInterceptor);
+
+    AssignSubInterceptorRequestMessage deliveredMessage = null;
+    _mailbox.OnMessageDelivered += (_, message) => {
+      if (message is AssignSubInterceptorRequestMessage assignRequest &&
+          ReferenceEquals(assignRequest.Receiver, parent)) {
+        deliveredMessage = assignRequest;
+      }
+    };
+
+    _mailbox.Configure(null);
+    _interceptor.AssignSubInterceptor(subInterceptor);
+
+    InvokePrivateMethod(_mailbox, "Update");
+
+    Assert.NotNull(deliveredMessage);
+    Assert.AreSame(_interceptor, deliveredMessage.Sender);
+    Assert.AreSame(parent, deliveredMessage.Receiver);
+    Assert.AreSame(subInterceptor, deliveredMessage.PayloadData.SubInterceptor);
+  }
+
+  // Verifies that reassignment propagation uses the mailbox when the interceptor has no remaining
+  // planned capacity.
+  [Test]
+  public void ReassignTarget_WithoutPlannedCapacity_SendsRequestToParentMailboxReceiver() {
+    SetPrivateField(_interceptor, "_capacityPerSubInterceptor", 1);
+    SetPrivateField(_interceptor, "_numSubInterceptorsPlannedRemaining", 0);
+    _interceptor.CommsParent = new StubAgent(Configs.AgentType.ShoreBattery);
+
+    var target = new FixedHierarchical(position: new Vector3(3f, 0f, 0f));
+    ReassignTargetRequestMessage deliveredMessage = null;
+    _mailbox.OnMessageDelivered += (_, message) => {
+      if (message is ReassignTargetRequestMessage reassignRequest &&
+          ReferenceEquals(reassignRequest.Receiver, _interceptor.CommsParent)) {
+        deliveredMessage = reassignRequest;
+      }
+    };
+
+    _mailbox.Configure(null);
+    _interceptor.ReassignTarget(target);
+
+    InvokePrivateMethod(_mailbox, "Update");
+
+    Assert.NotNull(deliveredMessage);
+    Assert.AreSame(_interceptor, deliveredMessage.Sender);
+    Assert.AreSame(_interceptor.CommsParent, deliveredMessage.Receiver);
+    Assert.AreSame(target, deliveredMessage.PayloadData.Target);
+  }
+
+  private static SimManager CreateSimManagerStub() {
+    return (SimManager)FormatterServices.GetUninitializedObject(typeof(SimManager));
+  }
+
+  private static Configs.StaticConfig CreateStaticConfig(Configs.AgentType agentType) {
+    return new Configs.StaticConfig {
+      AgentType = agentType,
+      BodyConfig = new Configs.BodyConfig { Mass = 1f, CrossSectionalArea = 1f },
+      LiftDragConfig = new Configs.LiftDragConfig { DragCoefficient = 1f, LiftDragRatio = 1f },
+    };
+  }
+
+  private static void SetMailboxInstance(Mailbox mailbox) {
+    FieldInfo instanceField = typeof(Mailbox).GetField(
+        "<Instance>k__BackingField", BindingFlags.NonPublic | BindingFlags.Static);
+    instanceField.SetValue(null, mailbox);
+  }
+
+  private static void SetSimManagerInstance(SimManager simManager) {
+    FieldInfo instanceField =
+        typeof(SimManager)
+            .GetField("<Instance>k__BackingField", BindingFlags.NonPublic | BindingFlags.Static);
+    instanceField.SetValue(null, simManager);
+  }
+
+  private void SetElapsedTime(float elapsedTime) {
+    FieldInfo elapsedTimeField = typeof(SimManager)
+                                     .GetField("<ElapsedTime>k__BackingField",
+                                               BindingFlags.NonPublic | BindingFlags.Instance);
+    elapsedTimeField.SetValue(_simManager, elapsedTime);
+  }
+
+  private sealed class TestInterceptor : InterceptorBase, IAgent {
+    public void InvokeAwakeForTest() {
+      base.Awake();
+    }
+
+    void IAgent.CreateTargetModel(IHierarchical target) {}
+
+    void IAgent.DestroyTargetModel() {}
+
+    void IAgent.UpdateTargetModel() {}
+  }
+
+  private sealed class StubInterceptor : IInterceptor {
+    private readonly int _capacity;
+
+    public event InterceptorEventHandler OnHit;
+    public event InterceptorEventHandler OnMiss;
+    public event InterceptorEventHandler OnDestroyed;
+    public event InterceptorEventHandler OnAssignSubInterceptor;
+    public event TargetReassignEventHandler OnReassignTarget;
+    public event AgentTerminatedEventHandler OnTerminated;
+
+    public HierarchicalAgent HierarchicalAgent { get; set; }
+    public Configs.StaticConfig StaticConfig { get; set; }
+    public Configs.AgentConfig AgentConfig { get; set; }
+    public IMovement Movement { get; set; }
+    public IController Controller { get; set; }
+    public ISensor Sensor { get; set; }
+    public IAgent TargetModel { get; set; }
+    public Vector3 Position { get; set; }
+    public Vector3 Velocity { get; set; } = Vector3.forward;
+    public float Speed => Velocity.magnitude;
+    public Vector3 Acceleration { get; set; }
+    public Vector3 AccelerationInput { get; set; }
+    public bool IsPursuer => true;
+    public float ElapsedTime => 0f;
+    public bool IsTerminated { get; private set; }
+    public GameObject gameObject => null;
+    public Transform Transform => null;
+    public Vector3 Up => Vector3.up;
+    public Vector3 Forward => Vector3.forward;
+    public Vector3 Right => Vector3.right;
+    public Quaternion InverseRotation => Quaternion.identity;
+    public IEscapeDetector EscapeDetector { get; set; }
+    public int Capacity => _capacity;
+    public int CapacityPerSubInterceptor => _capacity;
+    public int CapacityPlannedRemaining => _capacity;
+    public int CapacityRemaining => _capacity;
+    public int NumSubInterceptors => 0;
+    public int NumSubInterceptorsPlannedRemaining => 0;
+    public int NumSubInterceptorsRemaining => 0;
+    public bool IsReassignable => true;
+
+    public StubInterceptor(Configs.AgentType agentType, int capacity) {
+      _capacity = capacity;
+      StaticConfig = CreateStaticConfig(agentType);
+    }
+
+    public float MaxForwardAcceleration() => 1f;
+    public float MaxNormalAcceleration() => 1f;
+    public void CreateTargetModel(IHierarchical target) {}
+    public void DestroyTargetModel() {}
+    public void UpdateTargetModel() {}
+    public bool EvaluateReassignedTarget(IHierarchical target) => false;
+    public void AssignSubInterceptor(IInterceptor subInterceptor) {
+      OnAssignSubInterceptor?.Invoke(subInterceptor);
+    }
+    public void ReassignTarget(IHierarchical target) {
+      OnReassignTarget?.Invoke(target);
+    }
+
+    public void Terminate() {
+      IsTerminated = true;
+      OnTerminated?.Invoke(this);
+    }
+
+    public Transformation GetRelativeTransformation(IAgent target) => default;
+    public Transformation GetRelativeTransformation(IHierarchical target) => default;
+    public Transformation GetRelativeTransformation(in Vector3 waypoint) => default;
+  }
+
+  private sealed class StubAgent : IAgent {
+    public event AgentTerminatedEventHandler OnTerminated;
+
+    public HierarchicalAgent HierarchicalAgent { get; set; }
+    public Configs.StaticConfig StaticConfig { get; set; }
+    public Configs.AgentConfig AgentConfig { get; set; }
+    public IMovement Movement { get; set; }
+    public IController Controller { get; set; }
+    public ISensor Sensor { get; set; }
+    public IAgent TargetModel { get; set; }
+    public Vector3 Position { get; set; }
+    public Vector3 Velocity { get; set; }
+    public float Speed => Velocity.magnitude;
+    public Vector3 Acceleration { get; set; }
+    public Vector3 AccelerationInput { get; set; }
+    public bool IsPursuer => false;
+    public float ElapsedTime => 0f;
+    public bool IsTerminated { get; private set; }
+    public GameObject gameObject => null;
+    public Transform Transform => null;
+    public Vector3 Up => Vector3.up;
+    public Vector3 Forward => Vector3.forward;
+    public Vector3 Right => Vector3.right;
+    public Quaternion InverseRotation => Quaternion.identity;
+
+    public StubAgent(Configs.AgentType agentType) {
+      StaticConfig = CreateStaticConfig(agentType);
+    }
+
+    public float MaxForwardAcceleration() => 0f;
+    public float MaxNormalAcceleration() => 0f;
+    public void CreateTargetModel(IHierarchical target) {}
+    public void DestroyTargetModel() {}
+    public void UpdateTargetModel() {}
+
+    public void Terminate() {
+      IsTerminated = true;
+      OnTerminated?.Invoke(this);
+    }
+
+    public Transformation GetRelativeTransformation(IAgent target) => default;
+    public Transformation GetRelativeTransformation(IHierarchical target) => default;
+    public Transformation GetRelativeTransformation(in Vector3 waypoint) => default;
+  }
+}

--- a/Assets/Tests/EditMode/InterceptorBaseMailboxTests.cs
+++ b/Assets/Tests/EditMode/InterceptorBaseMailboxTests.cs
@@ -43,12 +43,12 @@ public class InterceptorBaseMailboxTests : TestBase {
     SetSimManagerInstance(null);
   }
 
-  // Verifies that a mailbox-delivered AssignTarget message updates the interceptor target.
+  // Verifies that a mailbox-delivered AssignTargetResponse message updates the interceptor target.
   [Test]
-  public void MailboxDelivery_AssignTargetMessage_AssignsHierarchicalTarget() {
+  public void MailboxDelivery_AssignTargetResponseMessage_AssignsHierarchicalTarget() {
     var target = new FixedHierarchical(position: new Vector3(10f, 0f, 0f));
-    var message =
-        new AssignTargetMessage(new StubAgent(Configs.AgentType.Vessel), _interceptor, target);
+    var message = new AssignTargetResponseMessage(new StubAgent(Configs.AgentType.Vessel),
+                                                  _interceptor, target);
 
     _mailbox.Configure(null);
     _mailbox.Send(message);
@@ -77,19 +77,51 @@ public class InterceptorBaseMailboxTests : TestBase {
     Assert.True(queuedTargets.Contains(target));
   }
 
+  // Verifies that a mailbox-delivered AssignTargetRequest message to a parent interceptor produces
+  // an AssignTargetResponse message for the requesting sub-interceptor.
+  [Test]
+  public void MailboxDelivery_AssignTargetRequest_SendsAssignTargetResponseToSubInterceptor() {
+    var expectedTarget = new FixedHierarchical(position: new Vector3(12f, 0f, 0f));
+    _interceptor.HierarchicalAgent.Target = CreateCluster(expectedTarget);
+
+    var subInterceptor = new StubInterceptor(Configs.AgentType.MissileInterceptor, capacity: 1);
+    subInterceptor.HierarchicalAgent = new HierarchicalAgent(subInterceptor);
+
+    AssignTargetResponseMessage deliveredMessage = null;
+    _mailbox.OnMessageDelivered += (_, message) => {
+      if (message is AssignTargetResponseMessage assignTargetResponse &&
+          ReferenceEquals(assignTargetResponse.Receiver, subInterceptor)) {
+        deliveredMessage = assignTargetResponse;
+      }
+    };
+
+    _mailbox.Configure(null);
+    _mailbox.Send(new AssignTargetRequestMessage(new StubAgent(Configs.AgentType.Vessel),
+                                                 _interceptor, subInterceptor));
+
+    InvokePrivateMethod(_mailbox, "Update");
+    Assert.IsNull(deliveredMessage);
+
+    InvokePrivateMethod(_mailbox, "Update");
+    Assert.NotNull(deliveredMessage);
+    Assert.AreSame(_interceptor, deliveredMessage.Sender);
+    Assert.AreSame(subInterceptor, deliveredMessage.Receiver);
+    Assert.AreSame(expectedTarget, deliveredMessage.PayloadData.Target);
+  }
+
   // Verifies that a sub-interceptor assignment request is sent through the mailbox to the parent
   // receiver when no target is currently available.
   [Test]
-  public void AssignSubInterceptor_WithoutTarget_SendsAssignRequestToParentMailboxReceiver() {
+  public void AssignSubInterceptor_WithoutTarget_SendsAssignTargetRequestToParentMailboxReceiver() {
     var parent = new StubAgent(Configs.AgentType.Vessel);
     _interceptor.CommsParent = parent;
 
     var subInterceptor = new StubInterceptor(Configs.AgentType.MissileInterceptor, capacity: 1);
     subInterceptor.HierarchicalAgent = new HierarchicalAgent(subInterceptor);
 
-    AssignSubInterceptorRequestMessage deliveredMessage = null;
+    AssignTargetRequestMessage deliveredMessage = null;
     _mailbox.OnMessageDelivered += (_, message) => {
-      if (message is AssignSubInterceptorRequestMessage assignRequest &&
+      if (message is AssignTargetRequestMessage assignRequest &&
           ReferenceEquals(assignRequest.Receiver, parent)) {
         deliveredMessage = assignRequest;
       }
@@ -144,6 +176,14 @@ public class InterceptorBaseMailboxTests : TestBase {
       BodyConfig = new Configs.BodyConfig { Mass = 1f, CrossSectionalArea = 1f },
       LiftDragConfig = new Configs.LiftDragConfig { DragCoefficient = 1f, LiftDragRatio = 1f },
     };
+  }
+
+  private static HierarchicalBase CreateCluster(params IHierarchical[] targets) {
+    var cluster = new HierarchicalBase();
+    foreach (IHierarchical target in targets) {
+      cluster.AddSubHierarchical(target);
+    }
+    return cluster;
   }
 
   private static void SetMailboxInstance(Mailbox mailbox) {

--- a/Assets/Tests/EditMode/InterceptorBaseMailboxTests.cs
+++ b/Assets/Tests/EditMode/InterceptorBaseMailboxTests.cs
@@ -81,6 +81,7 @@ public class InterceptorBaseMailboxTests : TestBase {
   // an AssignTargetResponse message for the requesting sub-interceptor.
   [Test]
   public void MailboxDelivery_AssignTargetRequest_SendsAssignTargetResponseToSubInterceptor() {
+    SetPrivateField(_interceptor, "_capacityPerSubInterceptor", 1);
     var expectedTarget = new FixedHierarchical(position: new Vector3(12f, 0f, 0f));
     _interceptor.HierarchicalAgent.Target = CreateCluster(expectedTarget);
 

--- a/Assets/Tests/EditMode/InterceptorBaseMailboxTests.cs
+++ b/Assets/Tests/EditMode/InterceptorBaseMailboxTests.cs
@@ -107,7 +107,11 @@ public class InterceptorBaseMailboxTests : TestBase {
     Assert.NotNull(deliveredMessage);
     Assert.AreSame(_interceptor, deliveredMessage.Sender);
     Assert.AreSame(subInterceptor, deliveredMessage.Receiver);
-    Assert.AreSame(expectedTarget, deliveredMessage.PayloadData.Target);
+
+    List<IHierarchical> assignedTargets = deliveredMessage.PayloadData.Target.LeafHierarchicals(
+        activeOnly: true, withTargetOnly: false);
+    Assert.AreEqual(1, assignedTargets.Count);
+    Assert.AreSame(expectedTarget, assignedTargets[0]);
   }
 
   // Verifies that a sub-interceptor assignment request is sent through the mailbox to the parent

--- a/Assets/Tests/EditMode/InterceptorBaseMailboxTests.cs.meta
+++ b/Assets/Tests/EditMode/InterceptorBaseMailboxTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 645d0f38b2a5d4766933397deb52320c


### PR DESCRIPTION
Files Modified:
InterceptorBase.cs



Description:
Replaced all ?.Invoke to SendRequest function calls at the bottom.

Added SendRequest Functions: SendAssignRequestToParent(IInterceptor subInterceptor), SendReassignRequestToParent(IHierarchical target), SendAssignTargetToSub(IInterceptor subInterceptor, IHierarchical target)

These SendRequest functions then call on SendMessage(Message message) that sends message into the mailbox.

When recieving messages it handles with OnMessage(Message message). OnMessage "opens/unpack" the messages and read and executes the information contained by the message envelopes. 
