### PR TITLE
[Communication] PR2: Mailbox Hooked Up With Agents, Added Tests and Examples

### DIFF
--- a/Assets/Scripts/Communication/Mailbox.cs
+++ b/Assets/Scripts/Communication/Mailbox.cs
@@ -70,8 +70,4 @@ public class Mailbox {
     }
     return communicationConfig.LinkConfig ?? _defaultLinkConfig;
   }
-
-  public void ClearPendingMessageQueue() {
-    _messageQueue.Clear();
-  }
 }

--- a/Assets/Scripts/Communication/Mailbox.cs
+++ b/Assets/Scripts/Communication/Mailbox.cs
@@ -70,4 +70,8 @@ public class Mailbox {
     }
     return communicationConfig.LinkConfig ?? _defaultLinkConfig;
   }
+
+  public void ClearPendingMessageQueue() {
+    _messageQueue.Clear();
+  }
 }

--- a/Assets/Scripts/Communication/Mailbox.cs
+++ b/Assets/Scripts/Communication/Mailbox.cs
@@ -32,8 +32,15 @@ public class Mailbox {
       float totalLatency = Math.Max(0f, latency + jitter);
       float deliverAt = SimManager.Instance.ElapsedTime + totalLatency;
 
-      var pendingMessage = new PendingMessage(message, deliverAt);
-      _messageQueue.Enqueue(pendingMessage, pendingMessage.DeliverAt);
+      // Deliver the message immediately if it is already due.
+      if (deliverAt <= SimManager.Instance.ElapsedTime) {
+        if (CommsManager.Instance.ContainsNode(message.Receiver)) {
+          message.Receiver.Receive(message);
+        }
+      } else {
+        var pendingMessage = new PendingMessage(message, deliverAt);
+        _messageQueue.Enqueue(pendingMessage, pendingMessage.DeliverAt);
+      }
     }
   }
 
@@ -42,10 +49,9 @@ public class Mailbox {
     while (!_messageQueue.IsEmpty() &&
            _messageQueue.Peek().DeliverAt <= SimManager.Instance.ElapsedTime) {
       PendingMessage pendingMessage = _messageQueue.Dequeue();
-      if (!CommsManager.Instance.ContainsNode(pendingMessage.Receiver)) {
-        continue;
+      if (CommsManager.Instance.ContainsNode(pendingMessage.Receiver)) {
+        pendingMessage.Receiver.Receive(pendingMessage.Message);
       }
-      pendingMessage.Receiver.Receive(pendingMessage.Message);
     }
   }
 

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -52,19 +52,6 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
   }
 
   private void OnDestroy() {
-    if (SimManager.Instance != null) {
-      SimManager.Instance.OnSimulationStarted -= RegisterSimulationStarted;
-      SimManager.Instance.OnSimulationEnded -= RegisterSimulationEnded;
-      SimManager.Instance.OnNewAsset -= RegisterNewAsset;
-      SimManager.Instance.OnNewLauncher -= RegisterNewLauncher;
-      SimManager.Instance.OnNewThreat -= RegisterNewThreat;
-    }
-    if (CommsNode != null) {
-      CommsNode.OnReceived -= HandleMessage;
-      if (CommsManager.Instance != null) {
-        CommsManager.Instance.RemoveNode(CommsNode);
-      }
-    }
     if (_hierarchyCoroutine != null) {
       StopCoroutine(_hierarchyCoroutine);
       _hierarchyCoroutine = null;
@@ -72,7 +59,6 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
   }
 
   private void RegisterSimulationStarted() {
-    CommsManager.Instance.AddNode(CommsNode);
     _hierarchyCoroutine = StartCoroutine(HierarchyManager(_hierarchyUpdatePeriod));
   }
 
@@ -165,8 +151,7 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
   }
 
   private void AssignSubInterceptor(IInterceptor subInterceptor) {
-    if (subInterceptor == null || subInterceptor.CapacityRemaining <= 0 ||
-        subInterceptor.CommsNode == null) {
+    if (subInterceptor == null || subInterceptor.CapacityRemaining <= 0) {
       return;
     }
 

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -52,8 +52,18 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
   }
 
   private void OnDestroy() {
+    if (SimManager.Instance != null) {
+      SimManager.Instance.OnSimulationStarted -= RegisterSimulationStarted;
+      SimManager.Instance.OnSimulationEnded -= RegisterSimulationEnded;
+      SimManager.Instance.OnNewAsset -= RegisterNewAsset;
+      SimManager.Instance.OnNewLauncher -= RegisterNewLauncher;
+      SimManager.Instance.OnNewThreat -= RegisterNewThreat;
+    }
     if (CommsNode != null) {
       CommsNode.OnReceived -= HandleMessage;
+      if (CommsManager.Instance != null) {
+        CommsManager.Instance.RemoveNode(CommsNode);
+      }
     }
     if (_hierarchyCoroutine != null) {
       StopCoroutine(_hierarchyCoroutine);

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -150,7 +150,8 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
   }
 
   private void AssignSubInterceptor(IInterceptor subInterceptor) {
-    if (subInterceptor.CapacityRemaining <= 0) {
+    if (subInterceptor == null || subInterceptor.IsTerminated ||
+        subInterceptor.CapacityRemaining <= 0) {
       return;
     }
 

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -47,10 +47,14 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
 
     // Create a communication node for the IADS.
     CommsNode = new CommsNode(Configs.AgentType.Iads);
+    CommsNode.OnReceived += HandleMessage;
     CommsManager.Instance.AddNode(CommsNode);
   }
 
   private void OnDestroy() {
+    if (CommsNode != null) {
+      CommsNode.OnReceived -= HandleMessage;
+    }
     if (_hierarchyCoroutine != null) {
       StopCoroutine(_hierarchyCoroutine);
       _hierarchyCoroutine = null;
@@ -58,6 +62,7 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
   }
 
   private void RegisterSimulationStarted() {
+    CommsManager.Instance.AddNode(CommsNode);
     _hierarchyCoroutine = StartCoroutine(HierarchyManager(_hierarchyUpdatePeriod));
   }
 
@@ -79,8 +84,7 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
 
   public void RegisterNewLauncher(IInterceptor launcher) {
     if (launcher.HierarchicalAgent != null) {
-      launcher.OnAssignSubInterceptor += AssignSubInterceptor;
-      launcher.OnReassignTarget += ReassignTarget;
+      launcher.SetParentCommsNode(CommsNode);
       _launchers.Add(launcher.HierarchicalAgent);
     }
   }
@@ -88,6 +92,20 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
   public void RegisterNewThreat(IThreat threat) {
     if (threat.HierarchicalAgent != null) {
       _newThreats.Add(threat.HierarchicalAgent);
+    }
+  }
+
+  private void HandleMessage(Message message) {
+    switch (message) {
+      case AssignTargetRequestMessage request:
+        AssignSubInterceptor(request.PayloadData.SubInterceptor);
+        break;
+      case ReassignTargetRequestMessage request:
+        ReassignTarget(request.PayloadData.Target);
+        break;
+      default:
+        Debug.LogWarning($"IADS received unexpected message type {message.Type}.");
+        break;
     }
   }
 
@@ -137,7 +155,8 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
   }
 
   private void AssignSubInterceptor(IInterceptor subInterceptor) {
-    if (subInterceptor.CapacityRemaining <= 0) {
+    if (subInterceptor == null || subInterceptor.CapacityRemaining <= 0 ||
+        subInterceptor.CommsNode == null) {
       return;
     }
 
@@ -150,7 +169,9 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
     foreach (var launcher in sortedLaunchers) {
       IHierarchical target = launcher.FindNewTarget(subInterceptor.HierarchicalAgent,
                                                     subInterceptor.CapacityRemaining);
-      if (subInterceptor.EvaluateReassignedTarget(target)) {
+      if (subInterceptor.ShouldAcceptReassignedTarget(target)) {
+        CommsManager.Instance.SendMessage(
+            new AssignTargetResponseMessage(CommsNode, subInterceptor.CommsNode, target));
         break;
       }
     }

--- a/Assets/Scripts/IADS/IADS.cs
+++ b/Assets/Scripts/IADS/IADS.cs
@@ -47,7 +47,7 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
 
     // Create a communication node for the IADS.
     CommsNode = new CommsNode(Configs.AgentType.Iads);
-    CommsNode.OnReceived += HandleMessage;
+    CommsNode.OnReceived += RegisterMessageReceived;
     CommsManager.Instance.AddNode(CommsNode);
   }
 
@@ -72,26 +72,26 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
     _newThreats.Clear();
   }
 
-  public void RegisterNewAsset(IInterceptor asset) {
+  private void RegisterNewAsset(IInterceptor asset) {
     if (asset.HierarchicalAgent != null) {
       _assets.Add(asset.HierarchicalAgent);
     }
   }
 
-  public void RegisterNewLauncher(IInterceptor launcher) {
+  private void RegisterNewLauncher(IInterceptor launcher) {
     if (launcher.HierarchicalAgent != null) {
-      launcher.SetParentCommsNode(CommsNode);
+      launcher.ParentCommsNode = CommsNode;
       _launchers.Add(launcher.HierarchicalAgent);
     }
   }
 
-  public void RegisterNewThreat(IThreat threat) {
+  private void RegisterNewThreat(IThreat threat) {
     if (threat.HierarchicalAgent != null) {
       _newThreats.Add(threat.HierarchicalAgent);
     }
   }
 
-  private void HandleMessage(Message message) {
+  private void RegisterMessageReceived(Message message) {
     switch (message) {
       case AssignTargetRequestMessage request:
         AssignSubInterceptor(request.PayloadData.SubInterceptor);
@@ -100,7 +100,6 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
         ReassignTarget(request.PayloadData.Target);
         break;
       default:
-        Debug.LogWarning($"IADS received unexpected message type {message.Type}.");
         break;
     }
   }
@@ -151,7 +150,7 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
   }
 
   private void AssignSubInterceptor(IInterceptor subInterceptor) {
-    if (subInterceptor == null || subInterceptor.CapacityRemaining <= 0) {
+    if (subInterceptor.CapacityRemaining <= 0) {
       return;
     }
 
@@ -164,7 +163,7 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
     foreach (var launcher in sortedLaunchers) {
       IHierarchical target = launcher.FindNewTarget(subInterceptor.HierarchicalAgent,
                                                     subInterceptor.CapacityRemaining);
-      if (subInterceptor.ShouldAcceptReassignedTarget(target)) {
+      if (target != null && !target.IsTerminated) {
         CommsManager.Instance.SendMessage(
             new AssignTargetResponseMessage(CommsNode, subInterceptor.CommsNode, target));
         break;
@@ -186,6 +185,7 @@ public class IADS : MonoBehaviour, ICommsEndpoint {
     if (closestLauncher == null) {
       return;
     }
-    closestLauncher.Interceptor.ReassignTarget(target);
+    CommsManager.Instance.SendMessage(
+        new ReassignTargetRequestMessage(CommsNode, closestLauncher.Interceptor.CommsNode, target));
   }
 }

--- a/Assets/Scripts/Interceptors/CarrierBase.cs
+++ b/Assets/Scripts/Interceptors/CarrierBase.cs
@@ -46,8 +46,7 @@ public abstract class CarrierBase : InterceptorBase {
 
         foreach (var agent in releasedAgents) {
           if (agent is IInterceptor subInterceptor) {
-            subInterceptor.OnAssignSubInterceptor += AssignSubInterceptor;
-            subInterceptor.OnReassignTarget += ReassignTarget;
+            subInterceptor.SetParentCommsNode(CommsNode);
             if (subInterceptor.Movement is MissileMovement movement) {
               movement.FlightPhase = Simulation.FlightPhase.Boost;
             }

--- a/Assets/Scripts/Interceptors/CarrierBase.cs
+++ b/Assets/Scripts/Interceptors/CarrierBase.cs
@@ -46,7 +46,7 @@ public abstract class CarrierBase : InterceptorBase {
 
         foreach (var agent in releasedAgents) {
           if (agent is IInterceptor subInterceptor) {
-            subInterceptor.SetParentCommsNode(CommsNode);
+            subInterceptor.ParentCommsNode = CommsNode;
             if (subInterceptor.Movement is MissileMovement movement) {
               movement.FlightPhase = Simulation.FlightPhase.Boost;
             }

--- a/Assets/Scripts/Interceptors/IInterceptor.cs
+++ b/Assets/Scripts/Interceptors/IInterceptor.cs
@@ -45,10 +45,6 @@ public interface IInterceptor : IAgent {
   // Return whether the interceptor should accept the new target.
   bool ShouldAcceptReassignedTarget(IHierarchical target);
 
-  // Evaluate whether the interceptor should be reassigned to the new target. Return whether the new
-  // target was accepted.
-  bool EvaluateReassignedTarget(IHierarchical target);
-
   // Assign a new target to the sub-interceptor.
   void AssignSubInterceptor(IInterceptor subInterceptor);
 

--- a/Assets/Scripts/Interceptors/IInterceptor.cs
+++ b/Assets/Scripts/Interceptors/IInterceptor.cs
@@ -14,6 +14,8 @@ public interface IInterceptor : IAgent {
 
   IEscapeDetector EscapeDetector { get; set; }
 
+  CommsNode ParentCommsNode { get; set; }
+
   // Maximum number of threats that this interceptor can target.
   int Capacity { get; }
 
@@ -38,16 +40,4 @@ public interface IInterceptor : IAgent {
 
   // If true, the interceptor can be reassigned to other targets.
   bool IsReassignable { get; }
-
-  // Set the parent communication node for the interceptor.
-  void SetParentCommsNode(CommsNode parentCommsNode);
-
-  // Return whether the interceptor should accept the new target.
-  bool ShouldAcceptReassignedTarget(IHierarchical target);
-
-  // Assign a new target to the sub-interceptor.
-  void AssignSubInterceptor(IInterceptor subInterceptor);
-
-  // Re-assign the target to another sub-interceptor.
-  void ReassignTarget(IHierarchical target);
 }

--- a/Assets/Scripts/Interceptors/IInterceptor.cs
+++ b/Assets/Scripts/Interceptors/IInterceptor.cs
@@ -12,14 +12,6 @@ public interface IInterceptor : IAgent {
   // a threat, e.g., through a ground collision.
   event Action<IInterceptor> OnDestroyed;
 
-  // The OnAssignSubInterceptor event handler is called when a sub-interceptor has no assigned
-  // target and should be assigned one.
-  event Action<IInterceptor> OnAssignSubInterceptor;
-
-  // The OnReassignTarget event handler is called when a target needs to be re-assigned to another
-  // interceptor.
-  event Action<IHierarchical> OnReassignTarget;
-
   IEscapeDetector EscapeDetector { get; set; }
 
   // Maximum number of threats that this interceptor can target.
@@ -46,6 +38,12 @@ public interface IInterceptor : IAgent {
 
   // If true, the interceptor can be reassigned to other targets.
   bool IsReassignable { get; }
+
+  // Set the parent communication node for the interceptor.
+  void SetParentCommsNode(CommsNode parentCommsNode);
+
+  // Return whether the interceptor should accept the new target.
+  bool ShouldAcceptReassignedTarget(IHierarchical target);
 
   // Evaluate whether the interceptor should be reassigned to the new target. Return whether the new
   // target was accepted.

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -9,8 +9,6 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   public event Action<IInterceptor> OnHit;
   public event Action<IInterceptor> OnMiss;
   public event Action<IInterceptor> OnDestroyed;
-  public event Action<IInterceptor> OnAssignSubInterceptor;
-  public event Action<IHierarchical> OnReassignTarget;
 
   // Default proportional navigation controller gain.
   private const float _proportionalNavigationGain = 5f;
@@ -78,7 +76,41 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   // Coroutine for handling unassigned targets.
   private Coroutine _unassignedTargetsCoroutine;
 
-  public bool EvaluateReassignedTarget(IHierarchical target) {
+  // Record the parent communication node for communication.
+  private CommsNode _parentCommsNode;
+
+  public void SetParentCommsNode(CommsNode parentCommsNode) {
+    _parentCommsNode = parentCommsNode;
+  }
+
+  private void SendAssignTargetRequest(IInterceptor subInterceptor) {
+    if (CommsNode == null || _parentCommsNode == null || subInterceptor?.CommsNode == null) {
+      return;
+    }
+    CommsManager.Instance.SendMessage(
+        new AssignTargetRequestMessage(CommsNode, _parentCommsNode, subInterceptor));
+  }
+
+  private void SendAssignTargetResponse(IInterceptor subInterceptor, IHierarchical target) {
+    if (CommsNode == null || subInterceptor?.CommsNode == null || target == null ||
+        target.IsTerminated) {
+      return;
+    }
+    CommsManager.Instance.SendMessage(
+        new AssignTargetResponseMessage(CommsNode, subInterceptor.CommsNode, target));
+  }
+
+  private void SendReassignTargetRequest(IHierarchical target) {
+    if (CommsNode == null || _parentCommsNode == null || target == null || target.IsTerminated) {
+      return;
+    }
+    CommsManager.Instance.SendMessage(
+        new ReassignTargetRequestMessage(CommsNode, _parentCommsNode, target));
+  }
+
+  // ShouldAcceptReassignedTarget only decides whether the interceptor should accept the new target.
+  // It does NOT assign the new target to the interceptor.
+  public bool ShouldAcceptReassignedTarget(IHierarchical target) {
     // Continue searching for targets if no target was found.
     if (target == null) {
       return false;
@@ -86,7 +118,6 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
 
     // If the interceptor has no target, always accept the new target.
     if (HierarchicalAgent.Target == null || HierarchicalAgent.Target.IsTerminated) {
-      HierarchicalAgent.Target = target;
       return true;
     }
 
@@ -94,26 +125,35 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     float currentFractionalSpeed =
         FractionalSpeed.Calculate(this, HierarchicalAgent.Target.Position);
     float newFractionalSpeed = FractionalSpeed.Calculate(this, target.Position);
-    if (newFractionalSpeed > currentFractionalSpeed) {
-      HierarchicalAgent.Target = target;
-      return true;
+    return newFractionalSpeed > currentFractionalSpeed;
+  }
+
+  // EvaluateReassignedTarget assigns the new target to the interceptor only after received from
+  // mailbox.
+  public bool EvaluateReassignedTarget(IHierarchical target) {
+    if (!ShouldAcceptReassignedTarget(target)) {
+      return false;
     }
-    return false;
+    HierarchicalAgent.Target = target;
+    return true;
   }
 
   public void AssignSubInterceptor(IInterceptor subInterceptor) {
-    if (subInterceptor.CapacityRemaining <= 0) {
+    if (subInterceptor == null || subInterceptor.CapacityRemaining <= 0) {
       return;
     }
 
     // Find a new target for the sub-interceptor within the parent interceptor's assigned targets.
     IHierarchical target = HierarchicalAgent.FindNewTarget(subInterceptor.HierarchicalAgent,
                                                            subInterceptor.CapacityRemaining);
-    // Evaluate the new target and decide whether to continue searching for other targets.
-    if (!subInterceptor.EvaluateReassignedTarget(target)) {
-      // Propagate the sub-interceptor target assignment to the parent interceptor above.
-      OnAssignSubInterceptor?.Invoke(subInterceptor);
+    if (target != null && !target.IsTerminated &&
+        subInterceptor.ShouldAcceptReassignedTarget(target)) {
+      SendAssignTargetResponse(subInterceptor, target);
+      return;
     }
+
+    // Propagate the sub-interceptor target assignment to the parent interceptor above.
+    SendAssignTargetRequest(subInterceptor);
   }
 
   public void ReassignTarget(IHierarchical target) {
@@ -124,7 +164,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     //  another sub-interceptor(s) to pursue the target(s).
     //  3. Propagate the target re-assignment to the parent interceptor above.
     if (CapacityPlannedRemaining <= 0) {
-      OnReassignTarget?.Invoke(target);
+      SendReassignTargetRequest(target);
       return;
     }
 
@@ -137,6 +177,24 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
         StartCoroutine(UnassignedTargetsManager(_unassignedTargetsLaunchPeriod));
     OnMiss += RegisterMiss;
     OnDestroyed += RegisterDestroyed;
+    CommsNode.OnReceived += HandleMessage;
+  }
+
+  private void HandleMessage(Message message) {
+    switch (message) {
+      case AssignTargetRequestMessage request:
+        AssignSubInterceptor(request.PayloadData.SubInterceptor);
+        break;
+      case AssignTargetResponseMessage response:
+        EvaluateReassignedTarget(response.PayloadData.Target);
+        break;
+      case ReassignTargetRequestMessage request:
+        ReassignTarget(request.PayloadData.Target);
+        break;
+      default:
+        Debug.LogWarning($"Message type {message.Type} is not valid.");
+        break;
+    }
   }
 
   protected override void FixedUpdate() {
@@ -156,7 +214,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
       List<IHierarchical> escapingTargets =
           targetHierarchicals.Where(EscapeDetector.IsEscaping).ToList();
       foreach (var target in escapingTargets) {
-        OnReassignTarget?.Invoke(target);
+        SendReassignTargetRequest(target);
       }
       if (escapingTargets.Count == targetHierarchicals.Count) {
         RequestReassignment(this);
@@ -179,6 +237,10 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
 
   protected override void OnDestroy() {
     base.OnDestroy();
+
+    if (CommsNode != null) {
+      CommsNode.OnReceived -= HandleMessage;
+    }
 
     if (_unassignedTargetsCoroutine != null) {
       StopCoroutine(_unassignedTargetsCoroutine);
@@ -288,7 +350,6 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     RequestTargetReassignment(interceptor);
 
     // Request a new target from the parent interceptor.
-    OnAssignSubInterceptor?.Invoke(interceptor);
   }
 
   private void RegisterDestroyed(IInterceptor interceptor) {
@@ -305,7 +366,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     List<IHierarchical> targetHierarchicals =
         target.LeafHierarchicals(activeOnly: true, withTargetOnly: false);
     foreach (var targetHierarchical in targetHierarchicals) {
-      OnReassignTarget?.Invoke(targetHierarchical);
+      SendReassignTargetRequest(targetHierarchical);
     }
 
     RequestReassignment(interceptor);
@@ -314,7 +375,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   private void RequestReassignment(IInterceptor interceptor) {
     if (interceptor.IsReassignable) {
       // Request a new target from the parent interceptor.
-      OnAssignSubInterceptor?.Invoke(interceptor);
+      SendAssignTargetRequest(interceptor);
     }
   }
 
@@ -344,7 +405,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
             filteredTargets.OrderBy(target => Vector3.Distance(Position, target.Position));
         var excessTargets = orderedTargets.Skip(CapacityPlannedRemaining);
         foreach (var target in excessTargets) {
-          OnReassignTarget?.Invoke(target);
+          SendReassignTargetRequest(target);
         }
         unassignedTargets = orderedTargets.Take(CapacityPlannedRemaining);
       } else {

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -263,7 +263,8 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   }
 
   private void AssignSubInterceptor(IInterceptor subInterceptor) {
-    if (subInterceptor == null || subInterceptor.CapacityRemaining <= 0) {
+    if (subInterceptor == null || subInterceptor.IsTerminated ||
+        subInterceptor.CapacityRemaining <= 0) {
       return;
     }
 

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -77,18 +77,18 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   private Coroutine _unassignedTargetsCoroutine;
 
   // Record the parent communication node for communication.
-  private CommsNode _parentCommsNode;
+  public CommsNode ParentCommsNode { get; set; }
 
   public void SetParentCommsNode(CommsNode parentCommsNode) {
-    _parentCommsNode = parentCommsNode;
+    ParentCommsNode = parentCommsNode;
   }
 
   private void SendAssignTargetRequest(IInterceptor subInterceptor) {
-    if (CommsNode == null || _parentCommsNode == null || subInterceptor?.CommsNode == null) {
+    if (CommsNode == null || ParentCommsNode == null || subInterceptor?.CommsNode == null) {
       return;
     }
     CommsManager.Instance.SendMessage(
-        new AssignTargetRequestMessage(CommsNode, _parentCommsNode, subInterceptor));
+        new AssignTargetRequestMessage(CommsNode, ParentCommsNode, subInterceptor));
   }
 
   private void SendAssignTargetResponse(IInterceptor subInterceptor, IHierarchical target) {
@@ -101,11 +101,11 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   }
 
   private void SendReassignTargetRequest(IHierarchical target) {
-    if (CommsNode == null || _parentCommsNode == null || target == null || target.IsTerminated) {
+    if (CommsNode == null || ParentCommsNode == null || target == null || target.IsTerminated) {
       return;
     }
     CommsManager.Instance.SendMessage(
-        new ReassignTargetRequestMessage(CommsNode, _parentCommsNode, target));
+        new ReassignTargetRequestMessage(CommsNode, ParentCommsNode, target));
   }
 
   // ShouldAcceptReassignedTarget only decides whether the interceptor should accept the new target.

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -84,7 +84,8 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   }
 
   private void SendAssignTargetRequest(IInterceptor subInterceptor) {
-    if (CommsNode == null || ParentCommsNode == null || subInterceptor?.CommsNode == null) {
+    if (CommsManager.Instance == null || CommsNode == null || ParentCommsNode == null ||
+        subInterceptor?.CommsNode == null) {
       return;
     }
     CommsManager.Instance.SendMessage(
@@ -92,8 +93,8 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   }
 
   private void SendAssignTargetResponse(IInterceptor subInterceptor, IHierarchical target) {
-    if (CommsNode == null || subInterceptor?.CommsNode == null || target == null ||
-        target.IsTerminated) {
+    if (CommsManager.Instance == null || CommsNode == null || subInterceptor?.CommsNode == null ||
+        target == null || target.IsTerminated) {
       return;
     }
     CommsManager.Instance.SendMessage(
@@ -101,7 +102,8 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   }
 
   private void SendReassignTargetRequest(IHierarchical target) {
-    if (CommsNode == null || ParentCommsNode == null || target == null || target.IsTerminated) {
+    if (CommsManager.Instance == null || CommsNode == null || ParentCommsNode == null ||
+        target == null || target.IsTerminated) {
       return;
     }
     CommsManager.Instance.SendMessage(
@@ -111,8 +113,8 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   // ShouldAcceptReassignedTarget only decides whether the interceptor should accept the new target.
   // It does NOT assign the new target to the interceptor.
   public bool ShouldAcceptReassignedTarget(IHierarchical target) {
-    // Continue searching for targets if no target was found.
-    if (target == null) {
+    // Continue searching if no valid target was found.
+    if (target == null || target.IsTerminated) {
       return false;
     }
 
@@ -146,8 +148,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     // Find a new target for the sub-interceptor within the parent interceptor's assigned targets.
     IHierarchical target = HierarchicalAgent.FindNewTarget(subInterceptor.HierarchicalAgent,
                                                            subInterceptor.CapacityRemaining);
-    if (target != null && !target.IsTerminated &&
-        subInterceptor.ShouldAcceptReassignedTarget(target)) {
+    if (subInterceptor.ShouldAcceptReassignedTarget(target)) {
       SendAssignTargetResponse(subInterceptor, target);
       return;
     }

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -130,7 +130,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
 
   // EvaluateReassignedTarget assigns the new target to the interceptor only after received from
   // mailbox.
-  public bool EvaluateReassignedTarget(IHierarchical target) {
+  private bool EvaluateReassignedTarget(IHierarchical target) {
     if (!ShouldAcceptReassignedTarget(target)) {
       return false;
     }

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -202,6 +202,8 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
 
     // Check whether the interceptor has a target. If not, request a new target from the parent
     // interceptor.
+    // TODO (Joseph): In the next PR, add "private bool _isAssignTargetRequestPending;" to prevent
+    // duplicate assignment requests while waiting for a mailbox response. (May overflow mailbox)
     if (HierarchicalAgent.Target == null || HierarchicalAgent.Target.IsTerminated) {
       RequestReassignment(this);
     }

--- a/Assets/Scripts/Interceptors/InterceptorBase.cs
+++ b/Assets/Scripts/Interceptors/InterceptorBase.cs
@@ -18,6 +18,8 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
 
   public IEscapeDetector EscapeDetector { get; set; }
 
+  public CommsNode ParentCommsNode { get; set; }
+
   // Maximum number of threats that this interceptor can target.
   [SerializeField]
   private int _capacity;
@@ -76,126 +78,13 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
   // Coroutine for handling unassigned targets.
   private Coroutine _unassignedTargetsCoroutine;
 
-  // Record the parent communication node for communication.
-  public CommsNode ParentCommsNode { get; set; }
-
-  public void SetParentCommsNode(CommsNode parentCommsNode) {
-    ParentCommsNode = parentCommsNode;
-  }
-
-  private void SendAssignTargetRequest(IInterceptor subInterceptor) {
-    if (CommsManager.Instance == null || CommsNode == null || ParentCommsNode == null ||
-        subInterceptor?.CommsNode == null) {
-      return;
-    }
-    CommsManager.Instance.SendMessage(
-        new AssignTargetRequestMessage(CommsNode, ParentCommsNode, subInterceptor));
-  }
-
-  private void SendAssignTargetResponse(IInterceptor subInterceptor, IHierarchical target) {
-    if (CommsManager.Instance == null || CommsNode == null || subInterceptor?.CommsNode == null ||
-        target == null || target.IsTerminated) {
-      return;
-    }
-    CommsManager.Instance.SendMessage(
-        new AssignTargetResponseMessage(CommsNode, subInterceptor.CommsNode, target));
-  }
-
-  private void SendReassignTargetRequest(IHierarchical target) {
-    if (CommsManager.Instance == null || CommsNode == null || ParentCommsNode == null ||
-        target == null || target.IsTerminated) {
-      return;
-    }
-    CommsManager.Instance.SendMessage(
-        new ReassignTargetRequestMessage(CommsNode, ParentCommsNode, target));
-  }
-
-  // ShouldAcceptReassignedTarget only decides whether the interceptor should accept the new target.
-  // It does NOT assign the new target to the interceptor.
-  public bool ShouldAcceptReassignedTarget(IHierarchical target) {
-    // Continue searching if no valid target was found.
-    if (target == null || target.IsTerminated) {
-      return false;
-    }
-
-    // If the interceptor has no target, always accept the new target.
-    if (HierarchicalAgent.Target == null || HierarchicalAgent.Target.IsTerminated) {
-      return true;
-    }
-
-    // Accept the new target if the intercept speed is higher.
-    float currentFractionalSpeed =
-        FractionalSpeed.Calculate(this, HierarchicalAgent.Target.Position);
-    float newFractionalSpeed = FractionalSpeed.Calculate(this, target.Position);
-    return newFractionalSpeed > currentFractionalSpeed;
-  }
-
-  // EvaluateReassignedTarget assigns the new target to the interceptor only after received from
-  // mailbox.
-  private bool EvaluateReassignedTarget(IHierarchical target) {
-    if (!ShouldAcceptReassignedTarget(target)) {
-      return false;
-    }
-    HierarchicalAgent.Target = target;
-    return true;
-  }
-
-  public void AssignSubInterceptor(IInterceptor subInterceptor) {
-    if (subInterceptor == null || subInterceptor.CapacityRemaining <= 0) {
-      return;
-    }
-
-    // Find a new target for the sub-interceptor within the parent interceptor's assigned targets.
-    IHierarchical target = HierarchicalAgent.FindNewTarget(subInterceptor.HierarchicalAgent,
-                                                           subInterceptor.CapacityRemaining);
-    if (subInterceptor.ShouldAcceptReassignedTarget(target)) {
-      SendAssignTargetResponse(subInterceptor, target);
-      return;
-    }
-
-    // Propagate the sub-interceptor target assignment to the parent interceptor above.
-    SendAssignTargetRequest(subInterceptor);
-  }
-
-  public void ReassignTarget(IHierarchical target) {
-    // If a target needs to be re-assigned, the interceptor should in the following order:
-    //  1. Queue up the unassigned targets in preparation of launching an additional
-    //  sub-interceptor.
-    //  2. If no existing sub-interceptor has been assigned to pursue the queued target(s), launch
-    //  another sub-interceptor(s) to pursue the target(s).
-    //  3. Propagate the target re-assignment to the parent interceptor above.
-    if (CapacityPlannedRemaining <= 0) {
-      SendReassignTargetRequest(target);
-      return;
-    }
-
-    _unassignedTargets.Add(target);
-  }
-
   protected override void Start() {
     base.Start();
     _unassignedTargetsCoroutine =
         StartCoroutine(UnassignedTargetsManager(_unassignedTargetsLaunchPeriod));
     OnMiss += RegisterMiss;
     OnDestroyed += RegisterDestroyed;
-    CommsNode.OnReceived += HandleMessage;
-  }
-
-  private void HandleMessage(Message message) {
-    switch (message) {
-      case AssignTargetRequestMessage request:
-        AssignSubInterceptor(request.PayloadData.SubInterceptor);
-        break;
-      case AssignTargetResponseMessage response:
-        EvaluateReassignedTarget(response.PayloadData.Target);
-        break;
-      case ReassignTargetRequestMessage request:
-        ReassignTarget(request.PayloadData.Target);
-        break;
-      default:
-        Debug.LogWarning($"Message type {message.Type} is not valid.");
-        break;
-    }
+    CommsNode.OnReceived += RegisterMessageReceived;
   }
 
   protected override void FixedUpdate() {
@@ -203,8 +92,7 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
 
     // Check whether the interceptor has a target. If not, request a new target from the parent
     // interceptor.
-    // TODO (Joseph): In the next PR, add "private bool _isAssignTargetRequestPending;" to prevent
-    // duplicate assignment requests while waiting for a mailbox response. (May overflow mailbox)
+    // TODO(Joseph0120): Prevent duplicate re-assignment requests while waiting for a response.
     if (HierarchicalAgent.Target == null || HierarchicalAgent.Target.IsTerminated) {
       RequestReassignment(this);
     }
@@ -240,10 +128,6 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
 
   protected override void OnDestroy() {
     base.OnDestroy();
-
-    if (CommsNode != null) {
-      CommsNode.OnReceived -= HandleMessage;
-    }
 
     if (_unassignedTargetsCoroutine != null) {
       StopCoroutine(_unassignedTargetsCoroutine);
@@ -359,6 +243,78 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
     RequestTargetReassignment(interceptor);
   }
 
+  private void RegisterMessageReceived(Message message) {
+    switch (message) {
+      case AssignTargetRequestMessage request:
+        AssignSubInterceptor(request.PayloadData.SubInterceptor);
+        break;
+      case AssignTargetResponseMessage response:
+        // If the re-assigned target was not accepted, the fixed update loop will request another
+        // target.
+        EvaluateReassignedTarget(response.PayloadData.Target);
+        break;
+      case ReassignTargetRequestMessage request:
+        ReassignTarget(request.PayloadData.Target);
+        break;
+      default:
+        Debug.LogWarning($"Message type {message.Type} is not valid.");
+        break;
+    }
+  }
+
+  private void AssignSubInterceptor(IInterceptor subInterceptor) {
+    if (subInterceptor == null || subInterceptor.CapacityRemaining <= 0) {
+      return;
+    }
+
+    // Find a new target for the sub-interceptor within the parent interceptor's assigned targets.
+    IHierarchical target = HierarchicalAgent.FindNewTarget(subInterceptor.HierarchicalAgent,
+                                                           subInterceptor.CapacityRemaining);
+    if (target != null && !target.IsTerminated) {
+      SendAssignTargetResponse(subInterceptor, target);
+      return;
+    }
+
+    // Propagate the sub-interceptor target assignment to the parent interceptor above.
+    SendAssignTargetRequest(subInterceptor);
+  }
+
+  // Evaluate whether the interceptor should be reassigned to the new target.
+  private void EvaluateReassignedTarget(IHierarchical target) {
+    if (target == null || target.IsTerminated) {
+      return;
+    }
+
+    // If the interceptor has no target, always accept the new target.
+    if (HierarchicalAgent.Target == null || HierarchicalAgent.Target.IsTerminated) {
+      HierarchicalAgent.Target = target;
+      return;
+    }
+
+    // Accept the new target if the intercept speed is higher.
+    float currentFractionalSpeed =
+        FractionalSpeed.Calculate(this, HierarchicalAgent.Target.Position);
+    float newFractionalSpeed = FractionalSpeed.Calculate(this, target.Position);
+    if (newFractionalSpeed > currentFractionalSpeed) {
+      HierarchicalAgent.Target = target;
+    }
+  }
+
+  private void ReassignTarget(IHierarchical target) {
+    // If a target needs to be re-assigned, the interceptor should in the following order:
+    //  1. Queue up the unassigned targets in preparation of launching an additional
+    //  sub-interceptor.
+    //  2. If no existing sub-interceptor has been assigned to pursue the queued target(s), launch
+    //  another sub-interceptor(s) to pursue the target(s).
+    //  3. Propagate the target re-assignment to the parent interceptor above.
+    if (CapacityPlannedRemaining <= 0) {
+      SendReassignTargetRequest(target);
+      return;
+    }
+
+    _unassignedTargets.Add(target);
+  }
+
   private void RequestTargetReassignment(IInterceptor interceptor) {
     // Request the parent interceptor to re-assign the target to another interceptor if there are no
     // other pursuers.
@@ -434,5 +390,20 @@ public abstract class InterceptorBase : AgentBase, IInterceptor {
       // Recursively cluster the newly assigned targets.
       newSubHierarchical.RecursiveCluster(maxClusterSize: CapacityPerSubInterceptor);
     }
+  }
+
+  private void SendAssignTargetRequest(IInterceptor subInterceptor) {
+    CommsManager.Instance.SendMessage(
+        new AssignTargetRequestMessage(CommsNode, ParentCommsNode, subInterceptor));
+  }
+
+  private void SendAssignTargetResponse(IInterceptor subInterceptor, IHierarchical target) {
+    CommsManager.Instance.SendMessage(
+        new AssignTargetResponseMessage(CommsNode, subInterceptor.CommsNode, target));
+  }
+
+  private void SendReassignTargetRequest(IHierarchical target) {
+    CommsManager.Instance.SendMessage(
+        new ReassignTargetRequestMessage(CommsNode, ParentCommsNode, target));
   }
 }

--- a/Assets/Scripts/Managers/CommsManager.cs
+++ b/Assets/Scripts/Managers/CommsManager.cs
@@ -12,10 +12,8 @@ public class CommsManager : MonoBehaviour {
   // Map from agent to the communication node.
   private readonly HashSet<CommsNode> _nodes = new HashSet<CommsNode>();
 
-  // Add a communication node. This function should only be used by the IADS.
+  // Add a communication node. This function should only be used by the IADS and in tests.
   public void AddNode(CommsNode node) => _nodes.Add(node);
-
-  public void RemoveNode(CommsNode node) => _nodes.Remove(node);
 
   public bool ContainsNode(CommsNode node) => _nodes.Contains(node);
 
@@ -29,19 +27,9 @@ public class CommsManager : MonoBehaviour {
 
   private void Start() {
     SimManager.Instance.OnSimulationStarted += _mailbox.Clear;
-    SimManager.Instance.OnSimulationEnded += HandleSimulationEnded;
+    SimManager.Instance.OnSimulationEnded += RegisterSimulationEnded;
     SimManager.Instance.OnNewInterceptor += RegisterNewAgent;
     SimManager.Instance.OnNewLauncher += RegisterNewAgent;
-  }
-
-  private void OnDestroy() {
-    if (SimManager.Instance == null || _mailbox == null) {
-      return;
-    }
-    SimManager.Instance.OnSimulationStarted -= _mailbox.Clear;
-    SimManager.Instance.OnSimulationEnded -= HandleSimulationEnded;
-    SimManager.Instance.OnNewInterceptor -= RegisterNewAgent;
-    SimManager.Instance.OnNewLauncher -= RegisterNewAgent;
   }
 
   private void FixedUpdate() {
@@ -52,7 +40,7 @@ public class CommsManager : MonoBehaviour {
     _mailbox.Send(message);
   }
 
-  private void HandleSimulationEnded() {
+  private void RegisterSimulationEnded() {
     _nodes.Clear();
     _mailbox.Clear();
   }
@@ -66,7 +54,7 @@ public class CommsManager : MonoBehaviour {
     var commsNode = new CommsNode(agent.StaticConfig.AgentType);
     agent.CommsNode = commsNode;
     agent.OnTerminated +=
-        _ => RemoveNode(commsNode);
+        _ => _nodes.Remove(commsNode);
     _nodes.Add(commsNode);
   }
 }

--- a/Assets/Scripts/Managers/CommsManager.cs
+++ b/Assets/Scripts/Managers/CommsManager.cs
@@ -12,9 +12,6 @@ public class CommsManager : MonoBehaviour {
   // Map from agent to the communication node.
   private readonly HashSet<CommsNode> _nodes = new HashSet<CommsNode>();
 
-  // Keep track of received messages for logging purposes.
-  private readonly HashSet<Message> _receivedMessages = new HashSet<Message>();
-
   // Add a communication node. This function should only be used by the IADS.
   public void AddNode(CommsNode node) => _nodes.Add(node);
 
@@ -55,6 +52,7 @@ public class CommsManager : MonoBehaviour {
     _mailbox.OnMessageReceived -= RegisterMessageReceived;
   }
 
+<<<<<<< HEAD
   private void RegisterMessageReceived(Message message) {
     if (message == null) {
       return;
@@ -67,6 +65,8 @@ public class CommsManager : MonoBehaviour {
   }
 
 >>>>>>> 6d8f8cecf (Added Logging and TODOs)
+=======
+>>>>>>> e450f4d3c (Fixed Titan Comments)
   private void FixedUpdate() {
     _mailbox.Deliver();
   }

--- a/Assets/Scripts/Managers/CommsManager.cs
+++ b/Assets/Scripts/Managers/CommsManager.cs
@@ -39,6 +39,10 @@ public class CommsManager : MonoBehaviour {
     _mailbox.Deliver();
   }
 
+  public void SendMessage(Message message) {
+    _mailbox.SendMessage(message);
+  }
+
   private void RegisterNewAgent(IAgent agent) {
     var commsNode = new CommsNode(agent.StaticConfig.AgentType);
     agent.CommsNode = commsNode;

--- a/Assets/Scripts/Managers/CommsManager.cs
+++ b/Assets/Scripts/Managers/CommsManager.cs
@@ -12,6 +12,9 @@ public class CommsManager : MonoBehaviour {
   // Map from agent to the communication node.
   private readonly HashSet<CommsNode> _nodes = new HashSet<CommsNode>();
 
+  // Keep track of received messages for logging purposes.
+  private readonly HashSet<Message> _receivedMessages = new HashSet<Message>();
+
   // Add a communication node. This function should only be used by the IADS.
   public void AddNode(CommsNode node) => _nodes.Add(node);
 
@@ -35,8 +38,35 @@ public class CommsManager : MonoBehaviour {
     };
     SimManager.Instance.OnNewInterceptor += RegisterNewAgent;
     SimManager.Instance.OnNewLauncher += RegisterNewAgent;
+    Mailbox.OnMessageReceived += RegisterMessageReceived;
   }
 
+<<<<<<< HEAD
+=======
+  private void OnDestroy() {
+    if (SimManager.Instance == null || _mailbox == null) {
+      return;
+    }
+    SimManager.Instance.OnSimulationEnded -= ClearNodes;
+    SimManager.Instance.OnSimulationStarted -= _mailbox.ClearPendingMessageQueue;
+    SimManager.Instance.OnSimulationEnded -= _mailbox.ClearPendingMessageQueue;
+    SimManager.Instance.OnNewInterceptor -= RegisterNewAgent;
+    SimManager.Instance.OnNewLauncher -= RegisterNewAgent;
+    Mailbox.OnMessageReceived -= RegisterMessageReceived;
+  }
+
+  private void RegisterMessageReceived(Message message) {
+    if (message == null) {
+      return;
+    }
+    _receivedMessages.Add(message);
+    // TODO (Joseph): Need to find a way to identify which agent sent/received the message for
+    // logging purposes. Currently it just shows EndpointType.
+    Debug.Log(
+        $"{message.Sender.EndpointType} sent {message.Type} to {message.Receiver.EndpointType}.");
+  }
+
+>>>>>>> 6d8f8cecf (Added Logging and TODOs)
   private void FixedUpdate() {
     _mailbox.Deliver();
   }

--- a/Assets/Scripts/Managers/CommsManager.cs
+++ b/Assets/Scripts/Managers/CommsManager.cs
@@ -29,50 +29,32 @@ public class CommsManager : MonoBehaviour {
 
   private void Start() {
     SimManager.Instance.OnSimulationStarted += _mailbox.Clear;
-    SimManager.Instance.OnSimulationEnded += () => {
-      _nodes.Clear();
-      _mailbox.Clear();
-    };
+    SimManager.Instance.OnSimulationEnded += HandleSimulationEnded;
     SimManager.Instance.OnNewInterceptor += RegisterNewAgent;
     SimManager.Instance.OnNewLauncher += RegisterNewAgent;
-    _mailbox.OnMessageReceived += RegisterMessageReceived;
   }
 
-<<<<<<< HEAD
-=======
   private void OnDestroy() {
     if (SimManager.Instance == null || _mailbox == null) {
       return;
     }
-    SimManager.Instance.OnSimulationEnded -= ClearNodes;
-    SimManager.Instance.OnSimulationStarted -= _mailbox.ClearPendingMessageQueue;
-    SimManager.Instance.OnSimulationEnded -= _mailbox.ClearPendingMessageQueue;
+    SimManager.Instance.OnSimulationStarted -= _mailbox.Clear;
+    SimManager.Instance.OnSimulationEnded -= HandleSimulationEnded;
     SimManager.Instance.OnNewInterceptor -= RegisterNewAgent;
     SimManager.Instance.OnNewLauncher -= RegisterNewAgent;
-    _mailbox.OnMessageReceived -= RegisterMessageReceived;
   }
 
-<<<<<<< HEAD
-  private void RegisterMessageReceived(Message message) {
-    if (message == null) {
-      return;
-    }
-    _receivedMessages.Add(message);
-    // TODO (Joseph): Need to find a way to identify which agent sent/received the message for
-    // logging purposes. Currently it just shows EndpointType.
-    Debug.Log(
-        $"{message.Sender.EndpointType} sent {message.Type} to {message.Receiver.EndpointType}.");
-  }
-
->>>>>>> 6d8f8cecf (Added Logging and TODOs)
-=======
->>>>>>> e450f4d3c (Fixed Titan Comments)
   private void FixedUpdate() {
     _mailbox.Deliver();
   }
 
   public void SendMessage(Message message) {
-    _mailbox.SendMessage(message);
+    _mailbox.Send(message);
+  }
+
+  private void HandleSimulationEnded() {
+    _nodes.Clear();
+    _mailbox.Clear();
   }
 
   private void RegisterNewAgent(IAgent agent) {

--- a/Assets/Scripts/Managers/CommsManager.cs
+++ b/Assets/Scripts/Managers/CommsManager.cs
@@ -38,7 +38,7 @@ public class CommsManager : MonoBehaviour {
     };
     SimManager.Instance.OnNewInterceptor += RegisterNewAgent;
     SimManager.Instance.OnNewLauncher += RegisterNewAgent;
-    Mailbox.OnMessageReceived += RegisterMessageReceived;
+    _mailbox.OnMessageReceived += RegisterMessageReceived;
   }
 
 <<<<<<< HEAD
@@ -52,7 +52,7 @@ public class CommsManager : MonoBehaviour {
     SimManager.Instance.OnSimulationEnded -= _mailbox.ClearPendingMessageQueue;
     SimManager.Instance.OnNewInterceptor -= RegisterNewAgent;
     SimManager.Instance.OnNewLauncher -= RegisterNewAgent;
-    Mailbox.OnMessageReceived -= RegisterMessageReceived;
+    _mailbox.OnMessageReceived -= RegisterMessageReceived;
   }
 
   private void RegisterMessageReceived(Message message) {

--- a/Assets/Scripts/Managers/CommsManager.cs
+++ b/Assets/Scripts/Managers/CommsManager.cs
@@ -15,6 +15,8 @@ public class CommsManager : MonoBehaviour {
   // Add a communication node. This function should only be used by the IADS.
   public void AddNode(CommsNode node) => _nodes.Add(node);
 
+  public void RemoveNode(CommsNode node) => _nodes.Remove(node);
+
   public bool ContainsNode(CommsNode node) => _nodes.Contains(node);
 
   private void Awake() {
@@ -44,10 +46,15 @@ public class CommsManager : MonoBehaviour {
   }
 
   private void RegisterNewAgent(IAgent agent) {
+    if (agent.CommsNode != null) {
+      _nodes.Add(agent.CommsNode);
+      return;
+    }
+
     var commsNode = new CommsNode(agent.StaticConfig.AgentType);
     agent.CommsNode = commsNode;
     agent.OnTerminated +=
-        _ => _nodes.Remove(commsNode);
+        _ => RemoveNode(commsNode);
     _nodes.Add(commsNode);
   }
 }

--- a/Assets/StreamingAssets/Configs/Simulations/5_swarms_100_ucav.pbtxt
+++ b/Assets/StreamingAssets/Configs/Simulations/5_swarms_100_ucav.pbtxt
@@ -295,3 +295,30 @@ threat_swarm_configs {
     }
   }
 }
+communication_config {
+  link_config {
+    latency_seconds: 0.10
+    latency_std_seconds: 0.02
+    packet_delivery_ratio: 1.0
+  }
+
+  link_overrides {
+    from: VESSEL
+    to: CARRIER_INTERCEPTOR
+    link_config {
+      latency_seconds: 0.25
+      latency_std_seconds: 0.02
+      packet_delivery_ratio: 0.98
+    }
+  }
+
+  link_overrides {
+    from: CARRIER_INTERCEPTOR
+    to: MISSILE_INTERCEPTOR
+    link_config {
+      latency_seconds: 0.45
+      latency_std_seconds: 0.01
+      packet_delivery_ratio: 0.99
+    }
+  }
+}

--- a/Assets/Tests/EditMode/MailboxTests.cs
+++ b/Assets/Tests/EditMode/MailboxTests.cs
@@ -1,0 +1,70 @@
+using NUnit.Framework;
+using System.Reflection;
+using UnityEngine;
+
+public class MailboxTests : TestBase {
+  private SimManager _simManager;
+  private CommsManager _commsManager;
+
+  [SetUp]
+  public void SetUp() {
+    _simManager = new GameObject("SimManager").AddComponent<SimManager>();
+    SetSingleton(_simManager);
+    _simManager.SimulationConfig = new Configs.SimulationConfig {
+      CommunicationConfig =
+          new Configs.CommunicationConfig {
+            LinkConfig =
+                new Configs.LinkConfig {
+                  LatencySeconds = 1f,
+                  PacketDeliveryRatio = 1f,
+                },
+          },
+    };
+    SetPrivateProperty(_simManager, "IsRunning", true);
+
+    _commsManager = new GameObject("CommsManager").AddComponent<CommsManager>();
+    SetSingleton(_commsManager);
+    SetPrivateField(_commsManager, "_mailbox", new Mailbox());
+  }
+
+  [TearDown]
+  public void TearDown() {
+    Object.DestroyImmediate(_commsManager.gameObject);
+    SetSingleton<CommsManager>(null);
+    Object.DestroyImmediate(_simManager.gameObject);
+    SetSingleton<SimManager>(null);
+  }
+
+  [Test]
+  public void SendMessage_DeliversAfterConfiguredLatency() {
+    var sender = new CommsNode(Configs.AgentType.Vessel);
+    var receiver = new CommsNode(Configs.AgentType.Iads);
+    _commsManager.AddNode(sender);
+    _commsManager.AddNode(receiver);
+
+    Message receivedMessage = null;
+    receiver.OnReceived += message => receivedMessage = message;
+    var sentMessage = new TestMessage(sender, receiver);
+
+    _commsManager.SendMessage(sentMessage);
+    InvokePrivateMethod(_commsManager, "FixedUpdate");
+    Assert.IsNull(receivedMessage);
+
+    SetPrivateProperty(_simManager, "ElapsedTime", 1f);
+    InvokePrivateMethod(_commsManager, "FixedUpdate");
+    Assert.AreSame(sentMessage, receivedMessage);
+  }
+
+  private sealed class TestPayload : IMessagePayload {}
+
+  private sealed class TestMessage : Message<TestPayload> {
+    public TestMessage(CommsNode sender, CommsNode receiver)
+        : base(sender, receiver, MessageType.AssignTargetRequest, new TestPayload()) {}
+  }
+
+  private static void SetSingleton<T>(T instance) {
+    typeof(T)
+        .GetProperty("Instance", BindingFlags.Public | BindingFlags.Static)
+        .SetValue(null, instance);
+  }
+}

--- a/Assets/Tests/EditMode/MailboxTests.cs
+++ b/Assets/Tests/EditMode/MailboxTests.cs
@@ -24,7 +24,6 @@ public class MailboxTests : TestBase {
 
     _commsManager = new GameObject("CommsManager").AddComponent<CommsManager>();
     SetSingleton(_commsManager);
-    SetPrivateField(_commsManager, "_mailbox", new Mailbox());
   }
 
   [TearDown]

--- a/Assets/Tests/EditMode/MailboxTests.cs
+++ b/Assets/Tests/EditMode/MailboxTests.cs
@@ -3,6 +3,13 @@ using System.Reflection;
 using UnityEngine;
 
 public class MailboxTests : TestBase {
+  private sealed class TestPayload : IMessagePayload {}
+
+  private sealed class TestMessage : Message<TestPayload> {
+    public TestMessage(CommsNode sender, CommsNode receiver)
+        : base(sender, receiver, MessageType.AssignTargetRequest, new TestPayload()) {}
+  }
+
   private SimManager _simManager;
   private CommsManager _commsManager;
 
@@ -24,14 +31,6 @@ public class MailboxTests : TestBase {
 
     _commsManager = new GameObject("CommsManager").AddComponent<CommsManager>();
     SetSingleton(_commsManager);
-  }
-
-  [TearDown]
-  public void TearDown() {
-    Object.DestroyImmediate(_commsManager.gameObject);
-    SetSingleton<CommsManager>(null);
-    Object.DestroyImmediate(_simManager.gameObject);
-    SetSingleton<SimManager>(null);
   }
 
   [Test]
@@ -68,36 +67,5 @@ public class MailboxTests : TestBase {
     InvokePrivateMethod(_commsManager, "FixedUpdate");
 
     Assert.IsNull(receivedMessage);
-  }
-
-  [Test]
-  public void SendMessage_DoesNotDeliverToRemovedReceiver() {
-    var sender = new CommsNode(Configs.AgentType.Vessel);
-    var receiver = new CommsNode(Configs.AgentType.Iads);
-    _commsManager.AddNode(sender);
-    _commsManager.AddNode(receiver);
-
-    Message receivedMessage = null;
-    receiver.OnReceived += message => receivedMessage = message;
-
-    _commsManager.SendMessage(new TestMessage(sender, receiver));
-    _commsManager.RemoveNode(receiver);
-    SetPrivateProperty(_simManager, "ElapsedTime", 1f);
-    InvokePrivateMethod(_commsManager, "FixedUpdate");
-
-    Assert.IsNull(receivedMessage);
-  }
-
-  private sealed class TestPayload : IMessagePayload {}
-
-  private sealed class TestMessage : Message<TestPayload> {
-    public TestMessage(CommsNode sender, CommsNode receiver)
-        : base(sender, receiver, MessageType.AssignTargetRequest, new TestPayload()) {}
-  }
-
-  private static void SetSingleton<T>(T instance) {
-    typeof(T)
-        .GetProperty("Instance", BindingFlags.Public | BindingFlags.Static)
-        .SetValue(null, instance);
   }
 }

--- a/Assets/Tests/EditMode/MailboxTests.cs
+++ b/Assets/Tests/EditMode/MailboxTests.cs
@@ -54,6 +54,40 @@ public class MailboxTests : TestBase {
     Assert.AreSame(sentMessage, receivedMessage);
   }
 
+  [Test]
+  public void SendMessage_DoesNotDeliverToUnregisteredReceiver() {
+    var sender = new CommsNode(Configs.AgentType.Vessel);
+    var receiver = new CommsNode(Configs.AgentType.Iads);
+    _commsManager.AddNode(sender);
+
+    Message receivedMessage = null;
+    receiver.OnReceived += message => receivedMessage = message;
+
+    _commsManager.SendMessage(new TestMessage(sender, receiver));
+    SetPrivateProperty(_simManager, "ElapsedTime", 1f);
+    InvokePrivateMethod(_commsManager, "FixedUpdate");
+
+    Assert.IsNull(receivedMessage);
+  }
+
+  [Test]
+  public void SendMessage_DoesNotDeliverToRemovedReceiver() {
+    var sender = new CommsNode(Configs.AgentType.Vessel);
+    var receiver = new CommsNode(Configs.AgentType.Iads);
+    _commsManager.AddNode(sender);
+    _commsManager.AddNode(receiver);
+
+    Message receivedMessage = null;
+    receiver.OnReceived += message => receivedMessage = message;
+
+    _commsManager.SendMessage(new TestMessage(sender, receiver));
+    _commsManager.RemoveNode(receiver);
+    SetPrivateProperty(_simManager, "ElapsedTime", 1f);
+    InvokePrivateMethod(_commsManager, "FixedUpdate");
+
+    Assert.IsNull(receivedMessage);
+  }
+
   private sealed class TestPayload : IMessagePayload {}
 
   private sealed class TestMessage : Message<TestPayload> {

--- a/Assets/Tests/EditMode/MailboxTests.cs.meta
+++ b/Assets/Tests/EditMode/MailboxTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e95e0bdf54e846f6abf88369715002af

--- a/Assets/Tests/TestBase.cs
+++ b/Assets/Tests/TestBase.cs
@@ -4,6 +4,12 @@ using System.Reflection;
 using UnityEngine;
 
 public abstract class TestBase {
+  protected void SetSingleton<T>(T instance) {
+    typeof(T)
+        .GetProperty("Instance", BindingFlags.Public | BindingFlags.Static)
+        .SetValue(null, instance);
+  }
+
   protected void SetPrivateField<T>(object obj, string fieldName, T value) {
     FieldInfo field = GetFieldInfo(obj, fieldName);
     field.SetValue(obj, value);

--- a/Assets/Tests/TestBase.cs
+++ b/Assets/Tests/TestBase.cs
@@ -5,9 +5,12 @@ using UnityEngine;
 
 public abstract class TestBase {
   protected void SetSingleton<T>(T instance) {
-    typeof(T)
-        .GetProperty("Instance", BindingFlags.Public | BindingFlags.Static)
-        .SetValue(null, instance);
+    PropertyInfo property =
+        typeof(T).GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
+    if (property == null) {
+      throw new Exception($"Property 'Instance' not found in type '{typeof(T).FullName}'.");
+    }
+    property.SetValue(null, instance);
   }
 
   protected void SetPrivateField<T>(object obj, string fieldName, T value) {

--- a/Pisterlab_Micromissile.slnx
+++ b/Pisterlab_Micromissile.slnx
@@ -1,0 +1,9 @@
+﻿<Solution>
+  <Project Path="bamlab.micromissiles.csproj" />
+  <Project Path="bamlab.test.editmode.csproj" />
+  <Project Path="bamlab.generated.csproj" />
+  <Project Path="Assembly-CSharp.csproj" />
+  <Project Path="Assembly-CSharp-Editor.csproj" />
+  <Project Path="bamlab.test.playmode.csproj" />
+  <Project Path="bamlab.test.csproj" />
+</Solution>

--- a/Pisterlab_Micromissile.slnx
+++ b/Pisterlab_Micromissile.slnx
@@ -1,9 +1,0 @@
-﻿<Solution>
-  <Project Path="bamlab.micromissiles.csproj" />
-  <Project Path="bamlab.test.editmode.csproj" />
-  <Project Path="bamlab.generated.csproj" />
-  <Project Path="Assembly-CSharp.csproj" />
-  <Project Path="Assembly-CSharp-Editor.csproj" />
-  <Project Path="bamlab.test.playmode.csproj" />
-  <Project Path="bamlab.test.csproj" />
-</Solution>


### PR DESCRIPTION
This PR links the mailbox-communication system with Agents - InterceptorBase, IADS, and CarrierBase.

Changes
- Assign-target requests, responses, and reassignment requests are routed through the communication mailbox.
- Sub-interceptors is linked to their corresponding parent's communication node.
- Interceptors and IADS can now handle different types of messages.
- "CommsManager" now registers communication nodes as a list.
- Block/Prevent delivery to removed receivers.
- Add latency, jitter, and per-link communication overrides to the `5_swarms_100_ucav` example.

Testing
Added mailbox tests verifying:
- Messages arrive after the configured latency.
- Messages do not arrive at unregistered receivers.

**Note
Packet delivery ratio is present (logic is flawed), but packet loss is not enabled yet - "Mailbox" currently uses a delivery ratio of "1" (Everything is delivered).